### PR TITLE
Stop modal screen from being long load time point

### DIFF
--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/dungeons/AbstractDungeon/ModalChoiceScreenUpdateRender.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/dungeons/AbstractDungeon/ModalChoiceScreenUpdateRender.java
@@ -20,7 +20,7 @@ public class ModalChoiceScreenUpdateRender
         )
         public static void Insert(AbstractDungeon __instance)
         {
-            if (AbstractDungeon.screen == ModalChoiceScreen.MODAL_CHOICE) {
+            if (AbstractDungeon.screen == ModalChoiceScreen.Enum.MODAL_CHOICE) {
                 BaseMod.modalChoiceScreen.update();
             }
         }
@@ -37,7 +37,7 @@ public class ModalChoiceScreenUpdateRender
         )
         public static void Insert(AbstractDungeon __instance, SpriteBatch sb)
         {
-            if (AbstractDungeon.screen == ModalChoiceScreen.MODAL_CHOICE) {
+            if (AbstractDungeon.screen == ModalChoiceScreen.Enum.MODAL_CHOICE) {
                 BaseMod.modalChoiceScreen.render(sb);
             }
         }
@@ -51,7 +51,7 @@ public class ModalChoiceScreenUpdateRender
     {
         public static void Postfix(AbstractDungeon.CurrentScreen s)
         {
-            if (s == ModalChoiceScreen.MODAL_CHOICE) {
+            if (s == ModalChoiceScreen.Enum.MODAL_CHOICE) {
                 BaseMod.modalChoiceScreen.reopen();
             }
         }

--- a/src/main/java/basemod/screens/ModalChoiceScreen.java
+++ b/src/main/java/basemod/screens/ModalChoiceScreen.java
@@ -14,8 +14,11 @@ import java.util.List;
 
 public class ModalChoiceScreen
 {
-    @SpireEnum
-    public static AbstractDungeon.CurrentScreen MODAL_CHOICE;
+    public static class Enum
+    {
+        @SpireEnum
+        public static AbstractDungeon.CurrentScreen MODAL_CHOICE;
+    }
 
     private static final Logger logger = LogManager.getLogger(ModalChoiceScreen.class.getName());
     private static float PAD_X;
@@ -35,7 +38,7 @@ public class ModalChoiceScreen
         AbstractDungeon.topPanel.unhoverHitboxes();
         cardGroup = cards;
         AbstractDungeon.isScreenUp = true;
-        AbstractDungeon.screen = MODAL_CHOICE;
+        AbstractDungeon.screen = Enum.MODAL_CHOICE;
         this.header = header;
         AbstractDungeon.dynamicBanner.appear(header);
         AbstractDungeon.overlayMenu.proceedButton.hide();
@@ -47,7 +50,7 @@ public class ModalChoiceScreen
 
     public void reopen()
     {
-        AbstractDungeon.screen = MODAL_CHOICE;
+        AbstractDungeon.screen = Enum.MODAL_CHOICE;
         AbstractDungeon.topPanel.unhoverHitboxes();
         AbstractDungeon.isScreenUp = true;
         AbstractDungeon.dynamicBanner.appear(header);


### PR DESCRIPTION
Coupled with https://github.com/kiooeht/ModTheSpire/commit/c313eea184cd43a26676aaa5c75443eaf59079ea, this moves the point at which loading pauses as the base game gets loaded back to `Setting isModded = true` rather than during enum patching.