### PR TITLE
Custom Banner Support

### DIFF
--- a/src/main/java/basemod/abstracts/CustomCard.java
+++ b/src/main/java/basemod/abstracts/CustomCard.java
@@ -57,6 +57,9 @@ public abstract class CustomCard extends AbstractCard {
 	public String textureOrbLargeImg = null;
 	public String textureBackgroundSmallImg = null;
 	public String textureBackgroundLargeImg = null;
+	public String textureBannerSmallImg = null;
+	public String textureBannerLargeImg = null;
+	
 	
 	public CustomCard(String id, String name, String img, int cost, String rawDescription, CardType type, CardColor color, CardRarity rarity, CardTarget target, int cardPool) {
 		super(id, name, "status/beta", "status/beta", cost, rawDescription, type, color, rarity, target, cardPool);
@@ -135,6 +138,34 @@ public abstract class CustomCard extends AbstractCard {
 		
 		loadTextureFromString(backgroundSmallImg);
 		loadTextureFromString(backgroundLargeImg);
+	}
+	
+	//
+	// per card banner functionality
+	//
+	
+	public Texture getBannerSmallTexture() {
+		if(textureBannerSmallImg == null) {
+			return null;
+		}
+		
+		return getTextureFromString(textureBannerSmallImg);
+	}
+	
+	public Texture getBannerLargeTexture() {
+		if(textureBannerLargeImg == null) {
+			return null;
+		}
+		
+		return getTextureFromString(textureBannerLargeImg);
+	}
+	
+	public void setBannerTexture(String bannerSmallImg, String bannerLargeImg) {
+		this.textureBannerSmallImg = bannerSmallImg;
+		this.textureBannerLargeImg = bannerLargeImg;
+		
+		loadTextureFromString(bannerSmallImg);
+		loadTextureFromString(bannerLargeImg);
 	}
 	
 	/**

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderFixSwitches.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderFixSwitches.java
@@ -22,6 +22,55 @@ import basemod.helpers.SuperclassFinder;
 
 public class RenderFixSwitches {
 
+	@SpirePatch(cls = "com.megacrit.cardcrawl.cards.AbstractCard", method = "renderBannerImage")
+	public static class RenderBannerSwitch {
+		public static final Logger logger = LogManager.getLogger(BaseMod.class.getName());
+		
+		public static void Replace(Object __obj_instance, SpriteBatch sb, float drawX, float drawY) {
+			AbstractCard card = (AbstractCard)__obj_instance;
+			AbstractCard.CardRarity rarity = card.rarity;
+			
+			Texture bannerTexture = null;
+			if (card instanceof CustomCard) {
+				bannerTexture = ((CustomCard)card).getBannerSmallTexture();
+			}
+			if(bannerTexture == null) {
+				switch(rarity.toString()) {
+				case "BASIC":
+				case "COMMON":
+				case "CURSE":
+					bannerTexture = ImageMaster.CARD_BANNER_COMMON;
+					break;
+				case "UNCOMMON":
+					bannerTexture = ImageMaster.CARD_BANNER_UNCOMMON;
+					break;
+				case "RARE":
+					bannerTexture = ImageMaster.CARD_BANNER_RARE;
+					break;
+					default:
+						bannerTexture = ImageMaster.CARD_BANNER_COMMON;
+				}
+			}
+			try {
+				Method renderHelperMethod;
+				Field renderColorField; 
+				
+				renderHelperMethod = SuperclassFinder.getSuperClassMethod(card.getClass(), "renderHelper", SpriteBatch.class, Color.class, Texture.class, float.class, float.class);
+				renderHelperMethod.setAccessible(true);
+				renderColorField = SuperclassFinder.getSuperclassField(card.getClass(), "renderColor");
+				renderColorField.setAccessible(true);
+				
+				Color renderColor = (Color) renderColorField.get(card);
+				renderHelperMethod.invoke(card, sb, renderColor, bannerTexture, drawX, drawY);
+			}
+			catch(IllegalAccessException | IllegalArgumentException | NoSuchFieldException | NoSuchMethodException | InvocationTargetException | SecurityException e) {
+				logger.error("could not render banner for card " + card.getClass().toString() + " with color " + card.color.toString());
+				logger.error("exception is: " + e.getMessage());
+				e.printStackTrace();
+			}
+		}
+	}
+	
 	@SpirePatch(cls = "com.megacrit.cardcrawl.cards.AbstractCard", method = "renderEnergy")
 	public static class RenderEnergySwitch {
 		public static final Logger logger = LogManager.getLogger(BaseMod.class.getName());

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/BackgroundFix.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/BackgroundFix.java
@@ -1,8 +1,11 @@
 package basemod.patches.com.megacrit.cardcrawl.screens.SingleCardViewPopup;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.evacipated.cardcrawl.modthespire.lib.LineFinder;
@@ -12,10 +15,13 @@ import com.evacipated.cardcrawl.modthespire.lib.SpireInsertPatch;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
 import com.evacipated.cardcrawl.modthespire.patcher.PatchingException;
 import com.megacrit.cardcrawl.cards.AbstractCard;
-import com.megacrit.cardcrawl.core.Settings;import com.megacrit.cardcrawl.screens.SingleCardViewPopup;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.helpers.ImageMaster;
+import com.megacrit.cardcrawl.screens.SingleCardViewPopup;
 
 import basemod.BaseMod;
 import basemod.abstracts.CustomCard;
+import basemod.helpers.SuperclassFinder;
 import javassist.CannotCompileException;
 import javassist.CtBehavior;
 
@@ -156,4 +162,51 @@ public class BackgroundFix {
 		}
 	}
 	
+	@SpirePatch(cls="com.megacrit.cardcrawl.screens.SingleCardViewPopup", method="renderCardBanner")
+	public static class BannerTexture {
+		public static void Replace(Object __obj_instance, SpriteBatch sb) {
+			try {
+				SingleCardViewPopup view = (SingleCardViewPopup)__obj_instance;
+				AbstractCard card;
+				
+				Field cardField;
+				cardField = view.getClass().getDeclaredField("card");
+				cardField.setAccessible(true);
+				
+				card = (AbstractCard)cardField.get(view);
+				
+				AbstractCard.CardRarity rarity = card.rarity;
+				
+				Texture bannerTexture = null;
+				if (card instanceof CustomCard) {
+					bannerTexture = ((CustomCard)card).getBannerLargeTexture();
+				}
+				if(bannerTexture == null) {
+					switch(rarity.toString()) {
+					case "BASIC":
+					case "COMMON":
+					case "CURSE":
+						bannerTexture = ImageMaster.CARD_BANNER_COMMON_L;
+						break;
+					case "UNCOMMON":
+						bannerTexture = ImageMaster.CARD_BANNER_UNCOMMON_L;
+						break;
+					case "RARE":
+						bannerTexture = ImageMaster.CARD_BANNER_RARE_L;
+						break;
+						default:
+							bannerTexture = ImageMaster.CARD_BANNER_COMMON_L;
+					}
+				}
+				sb.draw(bannerTexture, Settings.WIDTH / 2.0f - 512.0f, Settings.HEIGHT / 2.0f - 512.0f, 512.0f, 512.0f, 1024.0f, 1024.0f, 
+						Settings.scale, Settings.scale, 0.0f, 0,0,1024,1024, false, false);
+			} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+			
+			
+			
+		}
+	}
 }


### PR DESCRIPTION
This adds the method `CustomCard.setBannerTexture(String smallTexture, String largeTexture)` which lets the modder set a card specific banner. However the border around the card image is not changed.