### PR TITLE
Develop

### DIFF
--- a/src/main/java/basemod/BaseMod.java
+++ b/src/main/java/basemod/BaseMod.java
@@ -18,6 +18,7 @@ import basemod.helpers.dynamicvariables.BlockVariable;
 import basemod.helpers.dynamicvariables.DamageVariable;
 import basemod.helpers.dynamicvariables.MagicNumberVariable;
 import basemod.screens.ModalChoiceScreen;
+import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.evacipated.cardcrawl.modthespire.Loader;
 import com.evacipated.cardcrawl.modthespire.ModInfo;
 import com.megacrit.cardcrawl.relics.Circlet;
@@ -1315,6 +1316,37 @@ public class BaseMod {
 		return (ArrayList<String>) startingRelicsObj;
 	}
 
+	private static TextureAtlas.AtlasRegion getCardSmallEnergy() {
+		if (AbstractDungeon.player == null) {
+			return AbstractCard.orb_red;
+		}
+		switch (AbstractDungeon.player.chosenClass) {
+			case IRONCLAD:
+				return AbstractCard.orb_red;
+			case THE_SILENT:
+				return AbstractCard.orb_green;
+			case DEFECT:
+				return AbstractCard.orb_blue;
+			default:
+				// TODO: mod orbs
+				// TODO: Not requiring TextureAtlas.AtlasRegion
+				return AbstractCard.orb_red;
+		}
+	}
+
+	public static TextureAtlas.AtlasRegion getCardSmallEnergy(AbstractCard card) {
+		switch (card.color) {
+			case RED:
+				return AbstractCard.orb_red;
+			case GREEN:
+				return AbstractCard.orb_green;
+			case BLUE:
+				return AbstractCard.orb_blue;
+			default:
+				return getCardSmallEnergy();
+		}
+	}
+
 	// convert a playerClass String (fake ENUM) into the actual class ID for
 	// that class
 	public static String getClass(String playerClass) {
@@ -2156,6 +2188,8 @@ public class BaseMod {
 	// publishEditKeywords
 	public static void publishEditKeywords() {
 		logger.info("editting keywords");
+
+		addKeyword(new String[]{"[E]"}, GameDictionary.TEXT[0]);
 		
 		for (EditKeywordsSubscriber sub : editKeywordsSubscribers) {
 			sub.receiveEditKeywords();

--- a/src/main/java/basemod/BaseMod.java
+++ b/src/main/java/basemod/BaseMod.java
@@ -1316,7 +1316,7 @@ public class BaseMod {
 		return (ArrayList<String>) startingRelicsObj;
 	}
 
-	private static TextureAtlas.AtlasRegion getCardSmallEnergy() {
+	public static TextureAtlas.AtlasRegion getCardSmallEnergy() {
 		if (AbstractDungeon.player == null) {
 			return AbstractCard.orb_red;
 		}

--- a/src/main/java/basemod/BaseMod.java
+++ b/src/main/java/basemod/BaseMod.java
@@ -2469,6 +2469,18 @@ public class BaseMod {
 		toRemove.add(sub);
 	}
 
+	public static String convertToModID(String id) {
+		String modName = BaseMod.findCallingModName();
+		return convertToModID(modName, id);
+	}
+
+	public static String convertToModID(String modID, String id) {
+		if (modID != null && !id.startsWith(modID + ":")) {
+			id = modID + ":" + id;
+		}
+		return id;
+	}
+
 	public static boolean hasModID(String id) {
 		for (ModInfo info : Loader.MODINFOS) {
 			String modID = null;

--- a/src/main/java/basemod/BaseMod.java
+++ b/src/main/java/basemod/BaseMod.java
@@ -2475,7 +2475,9 @@ public class BaseMod {
 	}
 
 	public static String convertToModID(String modID, String id) {
-		if (modID != null && !id.startsWith(modID + ":")) {
+		if (modID == null && (id.startsWith("slaythespire:") || id.startsWith("sts:") || id.startsWith(":"))) {
+			return id.substring(id.indexOf(':') + 1);
+		} else if (modID != null && !id.startsWith(modID + ":")) {
 			id = modID + ":" + id;
 		}
 		return id;

--- a/src/main/java/basemod/abstracts/CustomCard.java
+++ b/src/main/java/basemod/abstracts/CustomCard.java
@@ -62,10 +62,15 @@ public abstract class CustomCard extends AbstractCard {
 	public String textureBackgroundLargeImg = null;
 	public String textureBannerSmallImg = null;
 	public String textureBannerLargeImg = null;
-	
-	
+
+
+	@Deprecated
 	public CustomCard(String id, String name, String img, int cost, String rawDescription, CardType type, CardColor color, CardRarity rarity, CardTarget target, int cardPool) {
-		super(id, name, "status/beta", "status/beta", cost, rawDescription, type, color, rarity, target, cardPool);
+		this(id, name, img, cost, rawDescription, type, color, rarity, target);
+	}
+	
+	public CustomCard(String id, String name, String img, int cost, String rawDescription, CardType type, CardColor color, CardRarity rarity, CardTarget target) {
+		super(id, name, "status/beta", "status/beta", cost, rawDescription, type, color, rarity, target);
 		
 		this.textureImg = img;
 		if (img != null) {

--- a/src/main/java/basemod/abstracts/cardbuilder/CardBasic.java
+++ b/src/main/java/basemod/abstracts/cardbuilder/CardBasic.java
@@ -23,7 +23,6 @@ public class CardBasic extends CustomCard {
 	public static final int BASE_MAX_UPGRADES = 1;
 	public static final int BASE_COST = -1;
 	public static final String BASE_DESCRIPTION = "";
-	public static final int BASE_POOL = 1;
 
 	protected boolean doDamage = false;
 	protected boolean doBlock = false;
@@ -60,7 +59,7 @@ public class CardBasic extends CustomCard {
 			CardType cardType, CardColor cardColor,
 			CardRarity rarity, CardTarget target) {
 		super(cardId, name, img, BASE_COST, BASE_DESCRIPTION,
-				cardType, cardColor, rarity, target, BASE_POOL);
+				cardType, cardColor, rarity, target);
 		
 		if (target == CardTarget.ALL_ENEMY) {
 			this.isMultiDamage = true;

--- a/src/main/java/basemod/helpers/ModalChoice.java
+++ b/src/main/java/basemod/helpers/ModalChoice.java
@@ -3,6 +3,8 @@ package basemod.helpers;
 import basemod.BaseMod;
 import basemod.abstracts.DynamicVariable;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +16,7 @@ public class ModalChoice
 {
     public interface Callback
     {
-        void optionSelected(int index);
+        void optionSelected(AbstractPlayer p, AbstractMonster m, int index);
     }
 
     private String title;

--- a/src/main/java/basemod/helpers/ModalChoiceCard.java
+++ b/src/main/java/basemod/helpers/ModalChoiceCard.java
@@ -38,7 +38,7 @@ public class ModalChoiceCard extends AbstractCard
     public void use(AbstractPlayer abstractPlayer, AbstractMonster abstractMonster)
     {
         if (callback != null) {
-            callback.optionSelected(index);
+            callback.optionSelected(abstractPlayer, abstractMonster, index);
         }
     }
 

--- a/src/main/java/basemod/helpers/ModalChoiceCard.java
+++ b/src/main/java/basemod/helpers/ModalChoiceCard.java
@@ -22,7 +22,7 @@ public class ModalChoiceCard extends AbstractCard
 
     ModalChoiceCard(String id, String name, String rawDescription, CardType type, CardColor color, CardTarget target, int index, ModalChoice.Callback callback)
     {
-        super(id, name, null, null, -2, rawDescription, type, color, CardRarity.BASIC, target, 0);
+        super(id, name, null, null, -2, rawDescription, type, color, CardRarity.BASIC, target);
         dontTriggerOnUseCard = true;
         if (type != CardType.POWER) {
             purgeOnUse = true;

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/CardIDModID.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/CardIDModID.java
@@ -20,15 +20,14 @@ import com.megacrit.cardcrawl.cards.DamageInfo;
                 "com.megacrit.cardcrawl.cards.AbstractCard$CardColor",
                 "com.megacrit.cardcrawl.cards.AbstractCard$CardRarity",
                 "com.megacrit.cardcrawl.cards.AbstractCard$CardTarget",
-                "com.megacrit.cardcrawl.cards.DamageInfo$DamageType",
-                "int"
+                "com.megacrit.cardcrawl.cards.DamageInfo$DamageType"
         }
 )
 public class CardIDModID
 {
     public static void Prefix(AbstractCard __instance, @ByRef String[] id, String name, String jokeUrl, String imgUrl, int cost, String rawDescription,
                               AbstractCard.CardType type, AbstractCard.CardColor color, AbstractCard.CardRarity rarity, AbstractCard.CardTarget target,
-                              DamageInfo.DamageType dType, int cardPool)
+                              DamageInfo.DamageType dType)
     {
         String modName = BaseMod.findCallingModName();
         if (modName != null && !id[0].startsWith(modName + ":")) {

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/CardIDModID.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/CardIDModID.java
@@ -29,9 +29,6 @@ public class CardIDModID
                               AbstractCard.CardType type, AbstractCard.CardColor color, AbstractCard.CardRarity rarity, AbstractCard.CardTarget target,
                               DamageInfo.DamageType dType)
     {
-        String modName = BaseMod.findCallingModName();
-        if (modName != null && !id[0].startsWith(modName + ":")) {
-            id[0] = modName + ":" + id[0];
-        }
+        id[0] = BaseMod.convertToModID(id[0]);
     }
 }

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderDescriptionEnergy.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderDescriptionEnergy.java
@@ -1,0 +1,129 @@
+package basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard;
+
+import basemod.BaseMod;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.GlyphLayout;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.evacipated.cardcrawl.modthespire.patcher.PatchingException;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.helpers.FontHelper;
+import javassist.CannotCompileException;
+import javassist.CtBehavior;
+
+import java.util.ArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RenderDescriptionEnergy
+{
+    private static Pattern r = Pattern.compile("\\[([RGBE])\\](\\.?) ");
+
+    @SpirePatch(
+            cls="com.megacrit.cardcrawl.cards.AbstractCard",
+            method="renderDescription"
+    )
+    public static class AlterTmp
+    {
+        @SpireInsertPatch(
+                rloc=31,
+                localvars={"tmp"}
+        )
+        public static void Insert(AbstractCard __instance, SpriteBatch sb, @ByRef String[] tmp)
+        {
+            Matcher m = r.matcher(tmp[0]);
+            if (m.find()) {
+                tmp[0] = "[E]" + (m.group(2).equals(".") ? "." : "") + " ";
+            }
+        }
+    }
+
+    @SpirePatch(
+            cls="com.megacrit.cardcrawl.cards.AbstractCard",
+            method="renderDescription"
+    )
+    public static class RenderSmallEnergyOrb
+    {
+        private static final float CARD_ENERGY_IMG_WIDTH = 24.0f * Settings.scale;
+
+        @SpireInsertPatch(
+                rloc=185,
+                localvars={"spacing", "i", "start_x", "draw_y", "font", "textColor", "tmp", "gl"}
+        )
+        public static void Insert(AbstractCard __instance, SpriteBatch sb, float spacing, int i, @ByRef float[] start_x, float draw_y,
+                                  BitmapFont font, Color textColor, @ByRef String[] tmp, GlyphLayout gl)
+        {
+            Matcher m = r.matcher(tmp[0]);
+            if (m.find()) {
+                gl.width = CARD_ENERGY_IMG_WIDTH * __instance.drawScale;
+                float tmp2 = (__instance.description.size() - 4) * spacing;
+                __instance.renderSmallEnergy(sb, BaseMod.getCardSmallEnergy(__instance),
+                        (start_x[0] - __instance.current_x) / Settings.scale / __instance.drawScale,
+                        -tmp2 - 172.0f + CARD_ENERGY_IMG_WIDTH * __instance.drawScale + i * spacing * 2.0f);
+                if (m.group(2).equals(".")) {
+                    FontHelper.renderRotatedText(sb, font, ".",
+                            __instance.current_x, __instance.current_y,
+                            start_x[0] - __instance.current_x + CARD_ENERGY_IMG_WIDTH * __instance.drawScale,
+                            i * 1.45f * -font.getCapHeight() + draw_y - __instance.current_y - 6.0f,
+                            __instance.angle, true, textColor);
+                }
+                start_x[0] += gl.width;
+                tmp[0] = "";
+            }
+        }
+    }
+
+    @SpirePatch(
+            cls="com.megacrit.cardcrawl.cards.AbstractCard",
+            method="initializeDescription"
+    )
+    public static class AlterEnergyKeyword
+    {
+        @SpireInsertPatch(
+                localvars={"word"}
+        )
+        public static void Insert(AbstractCard __instance, String word)
+        {
+            if (word.equals("[E]") && !__instance.keywords.contains("[E]")) {
+                __instance.keywords.add("[E]");
+            }
+        }
+
+        public static class Locator extends SpireInsertLocator
+        {
+            public int[] Locate(CtBehavior ctMethodToPatch) throws CannotCompileException, PatchingException
+            {
+                com.evacipated.cardcrawl.modthespire.lib.Matcher finalMatcher = new com.evacipated.cardcrawl.modthespire.lib.Matcher.MethodCallMatcher(
+                        "java.lang.String", "toLowerCase");
+
+                return LineFinder.findInOrder(ctMethodToPatch, new ArrayList<com.evacipated.cardcrawl.modthespire.lib.Matcher>(), finalMatcher);
+            }
+        }
+
+        public static void Postfix(AbstractCard __instance)
+        {
+            int[] idxs = new int[3];
+            idxs[0] = __instance.keywords.indexOf("[R]");
+            idxs[1] = __instance.keywords.indexOf("[G]");
+            idxs[2] = __instance.keywords.indexOf("[B]");
+
+            int idx = Integer.MAX_VALUE;
+            for (int i : idxs) {
+                if (i >= 0 && i < idx) {
+                    idx = i;
+                }
+            }
+
+            if (idx >= 0 && idx != Integer.MAX_VALUE) {
+                if (!__instance.keywords.contains("[E]")) {
+                    __instance.keywords.add(idx, "[E]");
+                }
+                __instance.keywords.remove("[R]");
+                __instance.keywords.remove("[G]");
+                __instance.keywords.remove("[B]");
+            }
+        }
+    }
+}

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderFixSwitches.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderFixSwitches.java
@@ -80,9 +80,9 @@ public class RenderFixSwitches {
 			AbstractCard card = (AbstractCard) __obj_instance;
 			CardColor color = card.color;
 			SpriteBatch sb = (SpriteBatch) sbObj;
-			
-			if (!color.toString().equals("RED") && !color.toString().equals("GREEN") && !color.toString().equals("BLUE")
-					&& !color.toString().equals("COLORLESS") && !color.toString().equals("CURSE")) {
+
+			if (color != CardColor.RED && color != CardColor.GREEN && color != CardColor.BLUE
+					&& color != CardColor.COLORLESS && color != CardColor.CURSE) {
 				Texture orbTexture = null;
 				try {
 					if (card instanceof CustomCard) {
@@ -137,8 +137,8 @@ public class RenderFixSwitches {
 			AbstractCard card = (AbstractCard) __obj_instance;
 			CardColor color = card.color;
 			SpriteBatch sb = (SpriteBatch) sbObj;
-			if (!color.toString().equals("RED") && !color.toString().equals("GREEN") && !color.toString().equals("BLUE")
-					&& !color.toString().equals("COLORLESS") && !color.toString().equals("CURSE")) {
+			if (color != CardColor.RED && color != CardColor.GREEN && color != CardColor.BLUE
+					&& color != CardColor.COLORLESS && color != CardColor.CURSE) {
 				Color glowColor = BaseMod.getGlowColor(color.toString());
 				if (glowColor == null) {
 					glowColor = Color.WHITE;
@@ -146,15 +146,15 @@ public class RenderFixSwitches {
 				try {
 					// use reflection hacks to invoke renderHelper (with float scale)
 					Field current_x;
-					current_x = card.getClass().getSuperclass().getSuperclass().getDeclaredField("current_x");
+					current_x = AbstractCard.class.getDeclaredField("current_x");
 					current_x.setAccessible(true);
 					Field current_y;
-					current_y = card.getClass().getSuperclass().getSuperclass().getDeclaredField("current_y");
+					current_y = AbstractCard.class.getDeclaredField("current_y");
 					current_y.setAccessible(true);
 					Field tintColor;
-					tintColor = card.getClass().getSuperclass().getSuperclass().getDeclaredField("tintColor");
+					tintColor = AbstractCard.class.getDeclaredField("tintColor");
 					tintColor.setAccessible(true);
-					Method renderHelperMethod = card.getClass().getSuperclass().getSuperclass().getDeclaredMethod("renderHelper", SpriteBatch.class,
+					Method renderHelperMethod = AbstractCard.class.getDeclaredMethod("renderHelper", SpriteBatch.class,
 							Color.class, Texture.class, float.class, float.class, float.class);
 					renderHelperMethod.setAccessible(true);
 					renderHelperMethod.invoke(card, sb, glowColor, card.getCardBg(),
@@ -181,9 +181,9 @@ public class RenderFixSwitches {
 			AbstractCard card = (AbstractCard) __obj_instance;
 			CardColor color = card.color;
 			SpriteBatch sb = (SpriteBatch) sbObj;
-			
-			if (!color.toString().equals("RED") && !color.toString().equals("GREEN") && !color.toString().equals("BLUE")
-					&& !color.toString().equals("COLORLESS") && !color.toString().equals("CURSE")) {
+
+			if (color != CardColor.RED && color != CardColor.GREEN && color != CardColor.BLUE
+					&& color != CardColor.COLORLESS && color != CardColor.CURSE) {
 				Texture bgTexture = null;
 				try {
 					if (card instanceof CustomCard) {

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/characters/AbstractPlayer/HasRelicModID.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/characters/AbstractPlayer/HasRelicModID.java
@@ -15,10 +15,7 @@ public class HasRelicModID
     public static void Prefix(AbstractPlayer __instance, @ByRef String[] targetID)
     {
         if (!targetID[0].equals(Circlet.ID) && !BaseMod.hasModID(targetID[0])) {
-            String modName = BaseMod.findCallingModName();
-            if (modName != null && !targetID[0].startsWith(modName + ":")) {
-                targetID[0] = modName + ":" + targetID[0];
-            }
+            targetID[0] = BaseMod.convertToModID(targetID[0]);
         }
     }
 }

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/dungeons/AbstractDungeon/InitializeCardPoolsSwitch.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/dungeons/AbstractDungeon/InitializeCardPoolsSwitch.java
@@ -3,8 +3,7 @@ package basemod.patches.com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import java.util.ArrayList;
 import java.util.Map;
 
-import com.evacipated.cardcrawl.modthespire.lib.SpireInsertPatch;
-import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.*;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.Settings;
@@ -13,11 +12,12 @@ import com.megacrit.cardcrawl.helpers.CardLibrary;
 import com.megacrit.cardcrawl.unlock.UnlockTracker;
 
 import basemod.BaseMod;
+import javassist.CtBehavior;
 
 @SpirePatch(cls="com.megacrit.cardcrawl.dungeons.AbstractDungeon", method="initializeCardPools")
 public class InitializeCardPoolsSwitch {
 
-	@SpireInsertPatch(rloc=26, localvars={"tmpPool"})
+	@SpireInsertPatch(localvars={"tmpPool"})
 	public static void Insert(Object __obj_instance, Object tmpPoolObj) {
 		AbstractPlayer player = AbstractDungeon.player;
 		AbstractPlayer.PlayerClass chosenClass = player.chosenClass;
@@ -35,5 +35,15 @@ public class InitializeCardPoolsSwitch {
 			}
 		}
 	}
-	
+
+	public static class Locator extends SpireInsertLocator {
+		@Override
+		public int[] Locate(CtBehavior ctBehavior) throws Exception
+		{
+			Matcher finalMatcher = new Matcher.MethodCallMatcher(
+					"com.megacrit.cardcrawl.dungeons.AbstractDungeon", "addColorlessCards");
+
+			return LineFinder.findInOrder(ctBehavior, new ArrayList<>(), finalMatcher);
+		}
+	}
 }

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/CardLibrary/GetCardModID.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/CardLibrary/GetCardModID.java
@@ -16,10 +16,7 @@ public class GetCardModID
     {
         public static void Prefix(@ByRef String[] key)
         {
-            String modName = BaseMod.findCallingModName();
-            if (modName != null && !key[0].startsWith(modName + ":")) {
-                key[0] = modName + ":" + key[0];
-            }
+            key[0] = BaseMod.convertToModID(key[0]);
         }
     }
 
@@ -32,10 +29,7 @@ public class GetCardModID
     {
         public static void Prefix(AbstractPlayer.PlayerClass plyrClass, @ByRef String[] key)
         {
-            String modName = BaseMod.findCallingModName();
-            if (modName != null && !key[0].startsWith(modName + ":")) {
-                key[0] = modName + ":" + key[0];
-            }
+            key[0] = BaseMod.convertToModID(key[0]);
         }
     }
 }

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/FontHelper/IdentifyOrb.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/FontHelper/IdentifyOrb.java
@@ -1,0 +1,20 @@
+package basemod.patches.com.megacrit.cardcrawl.helpers.FontHelper;
+
+import basemod.BaseMod;
+import com.badlogic.gdx.graphics.g2d.TextureAtlas;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+
+@SpirePatch(
+        cls="com.megacrit.cardcrawl.helpers.FontHelper",
+        method="identifyOrb"
+)
+public class IdentifyOrb
+{
+    public static TextureAtlas.AtlasRegion Postfix(TextureAtlas.AtlasRegion __result, String word)
+    {
+        if (__result == null && word.equals("[E]")) {
+            return BaseMod.getCardSmallEnergy();
+        }
+        return __result;
+    }
+}

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/RelicLibrary/GetRelicFix.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/RelicLibrary/GetRelicFix.java
@@ -25,10 +25,7 @@ public class GetRelicFix {
 
 	public static void Prefix(@ByRef String[] key) {
 		if (!key[0].equals(Circlet.ID) && !BaseMod.hasModID(key[0])) {
-			String modName = BaseMod.findCallingModName();
-			if (modName != null && !key[0].startsWith(modName + ":")) {
-				key[0] = modName + ":" + key[0];
-			}
+			key[0] = BaseMod.convertToModID(key[0]);
 		}
 	}
 	

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/TipHelper/RenderBoxEnergy.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/TipHelper/RenderBoxEnergy.java
@@ -1,0 +1,33 @@
+package basemod.patches.com.megacrit.cardcrawl.helpers.TipHelper;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import javassist.CannotCompileException;
+import javassist.expr.ExprEditor;
+import javassist.expr.MethodCall;
+
+@SpirePatch(
+        cls="com.megacrit.cardcrawl.helpers.TipHelper",
+        method="renderBox"
+)
+public class RenderBoxEnergy
+{
+    public static ExprEditor Instrument()
+    {
+        return new ExprEditor() {
+            @Override
+            public void edit(MethodCall m) throws CannotCompileException
+            {
+                if (m.getClassName().equals("com.megacrit.cardcrawl.helpers.FontHelper") && m.getMethodName().equals("renderFontLeftTopAligned")) {
+                    m.replace("if (word.equals(\"[E]\")) {" +
+                            "renderTipEnergy(sb, basemod.BaseMod.getCardSmallEnergy(card), x + TEXT_OFFSET_X, y + ORB_OFFSET_Y);" +
+                            "$3 = capitalize(TEXT[0]);" +
+                            "$4 = x + TEXT_OFFSET_X * 2.5f;" +
+                            "$_ = $proceed($$);" +
+                            "} else {" +
+                            "$_ = $proceed($$);" +
+                            "}");
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/localization/LocalizedStrings/GetCardStringsModID.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/localization/LocalizedStrings/GetCardStringsModID.java
@@ -13,9 +13,6 @@ public class GetCardStringsModID
 {
     public static void Prefix(LocalizedStrings __instance, @ByRef String[] cardName)
     {
-        String modName = BaseMod.findCallingModName();
-        if (modName != null && !cardName[0].startsWith(modName + ":")) {
-            cardName[0] = modName + ":" + cardName[0];
-        }
+        cardName[0] = BaseMod.convertToModID(cardName[0]);
     }
 }

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/relics/AbstractRelic/RelicIDModID.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/relics/AbstractRelic/RelicIDModID.java
@@ -21,10 +21,7 @@ public class RelicIDModID
     public static void Prefix(AbstractRelic __instance, @ByRef String[] setId, String imgName, AbstractRelic.RelicTier tier, AbstractRelic.LandingSound sfx)
     {
         if (!setId[0].equals(Circlet.ID) && !BaseMod.hasModID(setId[0])) {
-            String modName = BaseMod.findCallingModName();
-            if (modName != null && !setId[0].startsWith(modName + ":")) {
-                setId[0] = modName + ":" + setId[0];
-            }
+            setId[0] = BaseMod.convertToModID(setId[0]);
         }
     }
 }

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/CharSelectInfo/RelicIDModID.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/CharSelectInfo/RelicIDModID.java
@@ -36,7 +36,7 @@ public class RelicIDModID
                     modName = BaseMod.findCallingModName();
                 }
                 if (modName != null && !relics.get(i).startsWith(modName + ":")) {
-                    relics.set(i, modName + ":" + relics.get(i));
+                    relics.set(i, BaseMod.convertToModID(modName, relics.get(i)));
                 }
             }
         }
@@ -47,7 +47,7 @@ public class RelicIDModID
                     modName = BaseMod.findCallingModName();
                 }
                 if (modName != null && !deck.get(i).startsWith(modName + ":")) {
-                    deck.set(i, modName + ":" + deck.get(i));
+                    deck.set(i, BaseMod.convertToModID(modName, deck.get(i)));
                 }
             }
         }

--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/unlock/UnlockTracker/UnlockCardModID.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/unlock/UnlockTracker/UnlockCardModID.java
@@ -12,9 +12,6 @@ public class UnlockCardModID
 {
     public static void Prefix(@ByRef String[] key)
     {
-        String modName = BaseMod.findCallingModName();
-        if (modName != null && !key[0].startsWith(modName + ":")) {
-            key[0] = modName + ":" + key[0];
-        }
+        key[0] = BaseMod.convertToModID(key[0]);
     }
 }

--- a/src/main/java/basemod/test/Defend_Purple.java
+++ b/src/main/java/basemod/test/Defend_Purple.java
@@ -18,11 +18,10 @@ public class Defend_Purple extends CustomCard {
 	private static final int COST = 1;
 	private static final int BLOCK_AMT = 5;
 	private static final int UPGRADE_PLUS_BLOCK = 3;
-	private static final int POOL = 0;
 
 	public Defend_Purple() {
 		super(ID, NAME, TestMod.makePath(TestMod.ASSET_FOLDER, TestMod.DEFEND_PURPLE), COST, DESCRIPTION, AbstractCard.CardType.SKILL,
-				ColorEnumPatch.PURPLE, AbstractCard.CardRarity.BASIC, AbstractCard.CardTarget.SELF, POOL);
+				ColorEnumPatch.PURPLE, AbstractCard.CardRarity.BASIC, AbstractCard.CardTarget.SELF);
 
 		this.baseBlock = BLOCK_AMT;
 	}

--- a/src/main/java/basemod/test/Strike_Purple.java
+++ b/src/main/java/basemod/test/Strike_Purple.java
@@ -18,12 +18,11 @@ public class Strike_Purple extends CustomCard {
 	private static final int COST = 1;
 	private static final int ATTACK_DMG = 6;
 	private static final int UPGRADE_PLUS_DMG = 3;
-	private static final int POOL = 0;
 
 	public Strike_Purple() {
 		super(ID, NAME, TestMod.makePath(TestMod.ASSET_FOLDER, TestMod.STRIKE_PURPLE), COST, DESCRIPTION, AbstractCard.CardType.ATTACK,
 				ColorEnumPatch.PURPLE, AbstractCard.CardRarity.BASIC,
-				AbstractCard.CardTarget.ENEMY, POOL);
+				AbstractCard.CardTarget.ENEMY);
 
 		this.baseDamage = ATTACK_DMG;
 	}


### PR DESCRIPTION
Allows "[E]" to be used in card and relic descriptions to automatically use the right energy orb image. Work still needs to be done to allow mods to have custom small energy orb images.

Improves ModalChoice cards to allow the player and monster targets to be passed to the callback.

Fixes for the week 23 update.