### PR TITLE
Fix event command not accepting underscore ID's

### DIFF
--- a/src/main/java/basemod/BaseMod.java
+++ b/src/main/java/basemod/BaseMod.java
@@ -1196,6 +1196,8 @@ public class BaseMod {
 		default:
 			break;
 		}
+		
+		underScoreEventIDs.put(eventID.replace(' ', '_'), eventID);
 	}
 
 	public static HashMap<String, Class<? extends AbstractEvent>> getEventList(EventPool pool) {


### PR DESCRIPTION
fix for custom event ID's not working properly in the console.