### PR TITLE
Fix StartBattleHook is unavailable after save and reopen game

### DIFF
--- a/src/main/java/basemod/patches/com/megacrit/cardcrawl/rooms/AbstractRoom/StartBattleHook.java
+++ b/src/main/java/basemod/patches/com/megacrit/cardcrawl/rooms/AbstractRoom/StartBattleHook.java
@@ -1,17 +1,20 @@
 package basemod.patches.com.megacrit.cardcrawl.rooms.AbstractRoom;
 
 import basemod.BaseMod;
+import com.evacipated.cardcrawl.modthespire.lib.SpireInsertPatch;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import com.megacrit.cardcrawl.rooms.MonsterRoom;
 
 @SpirePatch(
-        cls = "com.megacrit.cardcrawl.rooms.MonsterRoom",
-        method = "onPlayerEntry"
+        cls = "com.megacrit.cardcrawl.rooms.AbstractRoom",
+        method = "update"
 )
 public class StartBattleHook {
 
-    public static void Prefix(MonsterRoom __instance) {
-        BaseMod.publishStartBattle(__instance);
+    @SpireInsertPatch(rloc = 44)
+    public static void Insert(AbstractRoom __instance) {
+        BaseMod.publishStartBattle((MonsterRoom) __instance);
     }
 
 }


### PR DESCRIPTION
I noticed that `StartBattleHook` and `receiveOnBattleStart` will not be triggered when save and reopen game in battle immediately.
I think the intention of `StartBattleHook` and `receiveOnBattleStart` are jusk like `AbstractRelic.atBattleStart`.
It should be triggered when reopen a save and join a battle immediately.Otherwise, It should be named as `EntryMonsterRoomHook`.
So I modified the patch.