### PR TITLE
Autocomplete ":" support and highlighted suggestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -465,3 +465,5 @@ This is a fast forward to v1.6.3 of daviscook477's fork with a few additional ch
 * Fix Diverse adding base character cards twice (kiooeht)
 
 #### dev ####
+* DevConsole AutoComplete: The active suggestion is now highlighted. Suggestions are 
+  now filled up to ":" (Skrelpoid)

--- a/src/main/java/basemod/AutoComplete.java
+++ b/src/main/java/basemod/AutoComplete.java
@@ -42,6 +42,7 @@ public class AutoComplete {
 
 	private static final int MAX_SUGGESTIONS = 5;
 	private static final Color TEXT_COLOR = Color.GRAY.cpy();
+	private static final Color HIGHLIGHT_COLOR = Color.LIGHT_GRAY.cpy();
 
 	public static boolean enabled = true;
 	public static int selectKey = Keys.SHIFT_LEFT;
@@ -964,7 +965,7 @@ public class AutoComplete {
 	}
 
 	public static void render(SpriteBatch sb) {
-		DevConsole.consoleFont.setColor(TEXT_COLOR);
+		DevConsole.consoleFont.setColor(HIGHLIGHT_COLOR);
 		if (shouldRenderInfo()) {
 			sb.draw(DevConsole.consoleBackground, getBGX(), DevConsole.CONSOLE_Y * Settings.scale, getWidth(),
 					-getHeight());
@@ -1011,6 +1012,7 @@ public class AutoComplete {
 				}
 				y -= (float) Math.floor(DevConsole.CONSOLE_TEXT_SIZE * Settings.scale);
 				DevConsole.consoleFont.draw(sb, suggestions.get(item), drawX, y);
+				DevConsole.consoleFont.setColor(TEXT_COLOR);
 			}
 		}
 		DevConsole.consoleFont.setColor(Color.WHITE);

--- a/src/main/java/basemod/DevConsole.java
+++ b/src/main/java/basemod/DevConsole.java
@@ -1086,7 +1086,7 @@ implements PostEnergyRechargeSubscriber, PostInitializeSubscriber, PostRenderSub
 
 		// if the key to delete the last token is pressed, delete the rightmost token
 		if (Gdx.input.isKeyJustPressed(AutoComplete.deleteTokenKey)) {
-			currentText = AutoComplete.getTextWithoutRightmostToken(true);
+			AutoComplete.removeOneTokenUsingSpaceAndIdDelimiter();
 			if (AutoComplete.enabled) {
 				AutoComplete.suggest(false);
 			}


### PR DESCRIPTION
closes #118 

This changes autocomplete behavior to stop at ":" which are used by some mods to write their card ids as modid:cardid.

Also because of feedback from the discord the top most suggestion (the one that will be filled in) now is drawn in a slightly lighter gray so it is easier to distinguish.