### PR TITLE
Unlock system fixes

### DIFF
--- a/mod/src/main/java/basemod/abstracts/CustomCard.java
+++ b/mod/src/main/java/basemod/abstracts/CustomCard.java
@@ -232,4 +232,8 @@ public abstract class CustomCard extends AbstractCard {
 	public boolean isDefend() {
 		return hasTag(BaseModCardTags.BASIC_DEFEND);
 	}
+
+	public void unlock() {
+		this.isLocked = false;
+	}
 }

--- a/mod/src/main/java/basemod/abstracts/CustomUnlockBundle.java
+++ b/mod/src/main/java/basemod/abstracts/CustomUnlockBundle.java
@@ -1,6 +1,7 @@
 package basemod.abstracts;
 
 import com.megacrit.cardcrawl.unlock.AbstractUnlock;
+import com.megacrit.cardcrawl.unlock.UnlockTracker;
 
 import java.util.ArrayList;
 
@@ -21,6 +22,17 @@ public class CustomUnlockBundle {
 		unlocks.add(unlock1);
 		unlocks.add(unlock2);
 		unlocks.add(unlock3);
+
+		if (type == AbstractUnlock.UnlockType.CARD) {
+			UnlockTracker.addCard(unlock1);
+			UnlockTracker.addCard(unlock2);
+			UnlockTracker.addCard(unlock3);
+		} else {
+
+			UnlockTracker.addRelic(unlock1);
+			UnlockTracker.addRelic(unlock2);
+			UnlockTracker.addRelic(unlock3);
+		}
 	}
 	
 	public ArrayList<CustomUnlock> getUnlocks() {


### PR DESCRIPTION
CustomCard overrides unlock method to avoid img trying to be set to base game's card image atlas during unlock process.  CustomUnlockBundle adds the cards or relics in the bundle to the UnlockTracker to prevent them from showing up in runs until unlocked.