### PR TITLE
Fix wrong line breaks when using unique keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -546,3 +546,4 @@ This is a fast forward to v1.6.3 of daviscook477's fork with a few additional ch
 * Fix hex code card text coloration in CN languages (JohnnyDevo)
 
 #### dev ####
+* Fix incorrect line breaks when using unique keywords (Celicath)

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/FixDescriptionWidthCustomDynamicVariable.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/FixDescriptionWidthCustomDynamicVariable.java
@@ -1,5 +1,6 @@
 package basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard;
 
+import basemod.BaseMod;
 import com.badlogic.gdx.graphics.g2d.GlyphLayout;
 import com.evacipated.cardcrawl.modthespire.lib.*;
 import com.megacrit.cardcrawl.cards.AbstractCard;
@@ -18,9 +19,14 @@ public class FixDescriptionWidthCustomDynamicVariable
             locator=Locator.class,
             localvars={"gl", "word"}
     )
-    public static void Insert(AbstractCard __instance, @ByRef GlyphLayout[] gl, String word)
+    public static void Insert(AbstractCard __instance, @ByRef GlyphLayout[] gl, @ByRef String[] word)
     {
-        if (word.startsWith("!")) {
+        if (BaseMod.keywordIsUnique(word[0].toLowerCase())) {
+            String prefix = BaseMod.getKeywordPrefix(word[0].toLowerCase());
+            word[0] = word[0].replaceFirst(prefix, "");
+            gl[0].width -= (new GlyphLayout(FontHelper.cardDescFont_N, prefix)).width;
+        }
+        else if (word[0].startsWith("!")) {
             gl[0] = new GlyphLayout(FontHelper.cardDescFont_N, "!D");
         }
     }

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/MultiwordKeywords.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/MultiwordKeywords.java
@@ -21,15 +21,10 @@ public class MultiwordKeywords
 	{
 		@SpireInsertPatch(
 				locator=Locator.class,
-				localvars={"word", "keywordTmp", "currentWidth"}
+				localvars={"word", "keywordTmp"}
 		)
-		public static void Insert(AbstractCard __instance, @ByRef String[] word, String keywordTmp, @ByRef float[] currentWidth)
+		public static void Insert(AbstractCard __instance, @ByRef String[] word, String keywordTmp)
 		{
-			if (BaseMod.keywordIsUnique(word[0].toLowerCase())) {
-				String prefix = BaseMod.getKeywordPrefix(word[0].toLowerCase());
-				word[0] = word[0].replaceFirst(prefix, "");
-				currentWidth[0] -= (new GlyphLayout(FontHelper.cardDescFont_N, prefix)).width;
-			}
 			if (word[0].contains("_") && !keywordTmp.contains("_")) {
 				String tmp = word[0].replace('_', ' ');
 				StringBuilder builder = new StringBuilder();

--- a/mod/src/main/resources/ModTheSpire.json
+++ b/mod/src/main/resources/ModTheSpire.json
@@ -3,7 +3,7 @@
   "name": "${artifactId}",
   "author_list": ["kiooeht", "test447"],
   "description": "Unofficial modding API for Slay the Spire. Also a Dev Console.",
-  "credits": "t-larson: Original creator of BaseMod.\nContributors: test447, Haashi, kiooeht, Blank The Evil, robojumper, FlipskiZ, DemoXin, Skrelpoid, kobting, twanvl, Moocowsgomoo, JohnnyDevo, MichaelMayhem, admiralbolt",
+  "credits": "t-larson: Original creator of BaseMod.\nContributors: test447, Haashi, kiooeht, Blank The Evil, robojumper, FlipskiZ, DemoXin, Skrelpoid, kobting, twanvl, Moocowsgomoo, JohnnyDevo, MichaelMayhem, admiralbolt, Celicath",
   "version": "${project.version}",
   "sts_version": "${SlayTheSpire.version}",
   "mts_version": "${ModTheSpire.version}",


### PR DESCRIPTION
![unfixed](https://user-images.githubusercontent.com/1008668/52201412-ab9b1a00-28ae-11e9-8dbd-7d2b9b5f83b8.png) ->![fixed](https://user-images.githubusercontent.com/1008668/52201414-ad64dd80-28ae-11e9-9854-c2f66aab618e.png)

The logic to determine line breaks considered the length of keyword prefix. This commit fixes that.

CN seems to have a similar issue, but issue there is more complicated and I can't really test so I didn't fix that in this PR.