### PR TITLE
Fix "blight add" command

### DIFF
--- a/mod/src/main/java/basemod/DevConsole.java
+++ b/mod/src/main/java/basemod/DevConsole.java
@@ -435,6 +435,8 @@ implements PostEnergyRechargeSubscriber, PostInitializeSubscriber, PostRenderSub
 				} else if (BlightHelper.getBlight(blightName) != null) {
 					AbstractDungeon.getCurrRoom().spawnBlightAndObtain(Settings.WIDTH / 2.0f, Settings.HEIGHT / 2.0f,
 							BlightHelper.getBlight(blightName));
+				} else {
+					log("invalid blight ID");
 				}
 			} else {
 				cmdBlightHelp();

--- a/mod/src/main/java/basemod/DevConsole.java
+++ b/mod/src/main/java/basemod/DevConsole.java
@@ -432,7 +432,7 @@ implements PostEnergyRechargeSubscriber, PostInitializeSubscriber, PostRenderSub
 				if (blight != null) {
 					 blight.incrementUp();
 					 blight.stack();
-				} else {
+				} else if (BlightHelper.getBlight(blightName) != null) {
 					AbstractDungeon.getCurrRoom().spawnBlightAndObtain(Settings.WIDTH / 2.0f, Settings.HEIGHT / 2.0f,
 							BlightHelper.getBlight(blightName));
 				}


### PR DESCRIPTION
No longer crashes if the user enters an invalid blight ID.