### PR TITLE
Feature/add audio subscriber

### DIFF
--- a/mod/src/main/java/basemod/BaseMod.java
+++ b/mod/src/main/java/basemod/BaseMod.java
@@ -592,6 +592,7 @@ public class BaseMod {
 		if (map != null) {
 			map.putAll(audioToAdd);
 			logger.info("Added " + audioToAdd.size() + " sounds");
+			audioToAdd.clear();
 		} else {
 			logger.warn("Unexpectedly failed to add sounds.");
 		}

--- a/mod/src/main/java/basemod/BaseMod.java
+++ b/mod/src/main/java/basemod/BaseMod.java
@@ -591,12 +591,14 @@ public class BaseMod {
 
 		if (map != null)
 		{
-			logger.info("added " + audioToAdd.size() + " sounds");
 			map.putAll(audioToAdd);
+			logger.info("added " + audioToAdd.size() + " sounds");
 		}
-		else {
-			logger.info("added 0 sounds");
+		else
+		{
+			logger.info("unexpectedly failed to add sounds.");
 		}
+
 
 		ReflectionHacks.setPrivate(__instance, SoundMaster.class, "map", map);
 	}
@@ -852,7 +854,7 @@ public class BaseMod {
 	{
 		FileHandle sfxFile = Gdx.files.internal(file); // Ensure audio is valid file
 
-		if (sfxFile != null) {
+		if (sfxFile != null && sfxFile.exists()) {
 			Sfx audioSfx = new Sfx(file, false);
 			audioToAdd.put(audioKey, audioSfx);
 		} else {

--- a/mod/src/main/java/basemod/BaseMod.java
+++ b/mod/src/main/java/basemod/BaseMod.java
@@ -589,13 +589,10 @@ public class BaseMod {
 		@SuppressWarnings("unchecked")
 		HashMap<String, Sfx> map = (HashMap<String, Sfx>) ReflectionHacks.getPrivate(__instance, SoundMaster.class, "map");
 
-		if (map != null)
-		{
+		if (map != null) {
 			map.putAll(audioToAdd);
 			logger.info("added " + audioToAdd.size() + " sounds");
-		}
-		else
-		{
+		} else {
 			logger.info("unexpectedly failed to add sounds.");
 		}
 

--- a/mod/src/main/java/basemod/BaseMod.java
+++ b/mod/src/main/java/basemod/BaseMod.java
@@ -591,9 +591,9 @@ public class BaseMod {
 
 		if (map != null) {
 			map.putAll(audioToAdd);
-			logger.info("added " + audioToAdd.size() + " sounds");
+			logger.info("Added " + audioToAdd.size() + " sounds");
 		} else {
-			logger.info("unexpectedly failed to add sounds.");
+			logger.warn("Unexpectedly failed to add sounds.");
 		}
 
 
@@ -855,7 +855,7 @@ public class BaseMod {
 			Sfx audioSfx = new Sfx(file, false);
 			audioToAdd.put(audioKey, audioSfx);
 		} else {
-			logger.info("Audio file: " + file + " was not found.");
+			logger.warn("Audio file: " + file + " was not found.");
 		}
 	}
 

--- a/mod/src/main/java/basemod/BaseMod.java
+++ b/mod/src/main/java/basemod/BaseMod.java
@@ -591,8 +591,8 @@ public class BaseMod {
 
 		if (map != null)
 		{
+			logger.info("added " + audioToAdd.size() + " sounds");
 			map.putAll(audioToAdd);
-			logger.info("added " + map.size() + " sounds");
 		}
 		else {
 			logger.info("added 0 sounds");

--- a/mod/src/main/java/basemod/BaseMod.java
+++ b/mod/src/main/java/basemod/BaseMod.java
@@ -12,6 +12,7 @@ import basemod.screens.ModalChoiceScreen;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.Version;
+import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
@@ -31,6 +32,8 @@ import com.evacipated.cardcrawl.modthespire.lib.SpireField;
 import com.evacipated.cardcrawl.modthespire.lib.SpireInitializer;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.megacrit.cardcrawl.audio.Sfx;
+import com.megacrit.cardcrawl.audio.SoundMaster;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
@@ -130,6 +133,7 @@ public class BaseMod {
 	private static ArrayList<EditRelicsSubscriber> editRelicsSubscribers;
 	private static ArrayList<EditCharactersSubscriber> editCharactersSubscribers;
 	private static ArrayList<EditStringsSubscriber> editStringsSubscribers;
+	private static ArrayList<AddAudioSubscriber> addAudioSubscribers;
 	private static ArrayList<EditKeywordsSubscriber> editKeywordsSubscribers;
 	private static ArrayList<PostBattleSubscriber> postBattleSubscribers;
 	private static ArrayList<SetUnlocksSubscriber> setUnlocksSubscribers;
@@ -181,6 +185,8 @@ public class BaseMod {
 	private static HashMap<String, AbstractPlayer.PlayerClass> potionPlayerClassMap;
 
 	private static HashMap<String, Class<? extends AbstractPower>> powerMap;
+
+	private static HashMap<String, Sfx> audioToAdd;
 
 	private static HashMap<String, String> keywordProperNames;
 	private static HashMap<String, String> keywordUniqueNames;
@@ -350,6 +356,9 @@ public class BaseMod {
 		initializePotionList();
 		initializePowerMap();
 		initializeUnderscorePowerIDs();
+
+		audioToAdd = new HashMap<>();
+
 		keywordProperNames = new HashMap<>();
 		keywordUniqueNames = new HashMap<>();
 		keywordUniquePrefixes = new HashMap<>();
@@ -439,6 +448,7 @@ public class BaseMod {
 		editRelicsSubscribers = new ArrayList<>();
 		editCharactersSubscribers = new ArrayList<>();
 		editStringsSubscribers = new ArrayList<>();
+		addAudioSubscribers = new ArrayList<>();
 		editKeywordsSubscribers = new ArrayList<>();
 		postBattleSubscribers = new ArrayList<>();
 		setUnlocksSubscribers = new ArrayList<>();
@@ -572,6 +582,23 @@ public class BaseMod {
 				}
 			}
 		}
+	}
+
+	// Add Sfx in audio map to SoundMaster
+	private static void addAudioToSoundMaster(SoundMaster __instance) {
+		@SuppressWarnings("unchecked")
+		HashMap<String, Sfx> map = (HashMap<String, Sfx>) ReflectionHacks.getPrivate(__instance, SoundMaster.class, "map");
+
+		if (map != null)
+		{
+			map.putAll(audioToAdd);
+			logger.info("added " + map.size() + " sounds");
+		}
+		else {
+			logger.info("added 0 sounds");
+		}
+
+		ReflectionHacks.setPrivate(__instance, SoundMaster.class, "map", map);
 	}
 
 	static void initializeEncounters() {
@@ -818,6 +845,19 @@ public class BaseMod {
 	// custom remove colors -
 	public static ArrayList<AbstractCard.CardColor> getCustomCardsToRemoveColors() {
 		return customToRemoveColors;
+	}
+
+	// add audio to add
+	public static void addAudio(String audioKey, String file)
+	{
+		FileHandle sfxFile = Gdx.files.internal(file); // Ensure audio is valid file
+
+		if (sfxFile != null) {
+			Sfx audioSfx = new Sfx(file, false);
+			audioToAdd.put(audioKey, audioSfx);
+		} else {
+			logger.info("Audio file: " + file + " was not found.");
+		}
 	}
 
 	// add card
@@ -2354,6 +2394,19 @@ public class BaseMod {
 		unsubscribeLaterHelper(EditStringsSubscriber.class);
 	}
 
+	// publishAddAudio -
+	public static void publishAddAudio(SoundMaster __instance) {
+		logger.info("begin adding custom sounds");
+
+		for (AddAudioSubscriber sub : addAudioSubscribers) {
+			sub.receiveAddAudio();
+		}
+
+		BaseMod.addAudioToSoundMaster(__instance);
+
+		unsubscribeLaterHelper(AddAudioSubscriber.class);
+	}
+
 	// publishPostBattle -
 	public static void publishPostBattle(AbstractRoom battleRoom) {
 		logger.info("publish post combat");
@@ -2593,6 +2646,7 @@ public class BaseMod {
 		subscribeIfInstance(postCreateShopRelicSubscribers, sub, PostCreateShopRelicSubscriber.class);
 		subscribeIfInstance(postCreateShopPotionSubscribers, sub, PostCreateShopPotionSubscriber.class);
 		subscribeIfInstance(editCardsSubscribers, sub, EditCardsSubscriber.class);
+		subscribeIfInstance(addAudioSubscribers, sub, AddAudioSubscriber.class);
 		subscribeIfInstance(editRelicsSubscribers, sub, EditRelicsSubscriber.class);
 		subscribeIfInstance(editCharactersSubscribers, sub, EditCharactersSubscriber.class);
 		subscribeIfInstance(editStringsSubscribers, sub, EditStringsSubscriber.class);
@@ -2819,6 +2873,8 @@ public class BaseMod {
 			editStringsSubscribers.remove(sub);
 		} else if (removalClass.equals(EditKeywordsSubscriber.class)) {
 			editKeywordsSubscribers.remove(sub);
+		} else if (removalClass.equals(AddAudioSubscriber.class)) {
+			addAudioSubscribers.remove(sub);
 		} else if (removalClass.equals(PostBattleSubscriber.class)) {
 			postBattleSubscribers.remove(sub);
 		} else if (removalClass.equals(SetUnlocksSubscriber.class)) {

--- a/mod/src/main/java/basemod/interfaces/AddAudioSubscriber.java
+++ b/mod/src/main/java/basemod/interfaces/AddAudioSubscriber.java
@@ -1,0 +1,5 @@
+package basemod.interfaces;
+
+public interface AddAudioSubscriber extends ISubscriber {
+    void receiveAddAudio();
+}

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/audio/SoundMaster/AddAudio.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/audio/SoundMaster/AddAudio.java
@@ -4,8 +4,10 @@ import basemod.BaseMod;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
 import com.megacrit.cardcrawl.audio.SoundMaster;
 
-@SpirePatch(clz=SoundMaster.class, method=SpirePatch.CONSTRUCTOR)
-
+@SpirePatch(
+        clz=SoundMaster.class,
+        method=SpirePatch.CONSTRUCTOR
+)
 public class AddAudio {
     public static void Postfix(SoundMaster __obj_instance) {
         BaseMod.publishAddAudio(__obj_instance);

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/audio/SoundMaster/AddAudio.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/audio/SoundMaster/AddAudio.java
@@ -1,0 +1,13 @@
+package basemod.patches.com.megacrit.cardcrawl.audio.SoundMaster;
+
+import basemod.BaseMod;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.audio.SoundMaster;
+
+@SpirePatch(clz=SoundMaster.class, method=SpirePatch.CONSTRUCTOR)
+
+public class AddAudio {
+    public static void Postfix(SoundMaster __obj_instance) {
+        BaseMod.publishAddAudio(__obj_instance);
+    }
+}


### PR DESCRIPTION
Adds a new subscriber and a method to be used within it, which will add sfx to the SoundMaster.

To use:
`implements AddAudioSubscriber`

```
public void receiveAddAudio() {
    BaseMod.addAudio("sfxKey", "sfxFile");
}
```

as an example of what would be a proper use, to avoid conflict in the SoundMaster hashmap

```
public void receiveAddAudio() {
    BaseMod.addAudio("modname:soundName", "ModResourceFolder/audio/audiofile.ogg");
}
```

Then the sound can be played with

`CardCrawlGame.sound.play("modname:soundName", pitchVariation);`
or any other standard sound playing methods for StS, such as the SfxAction.

For more practical use, sound keys would likely be saved as static final Strings.

Any audio files that are added but not found will output a message to the log, such as

```
05:52:44.303 INFO basemod.BaseMod> begin adding custom sounds
05:52:44.307 INFO basemod.BaseMod> Audio file: there/is/no/way/this/could/possibly/exist was not found.
```