### PR TITLE
Shrink Long Description upgraded cards fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -565,3 +565,4 @@ This is a fast forward to v1.6.3 of daviscook477's fork with a few additional ch
 
 #### dev ####
 * Fix not auto-registering bottle relics when added to custom pool
+* Fix to Shrink Long Description feature, when description font size was not correct after card was upgraded (JohnnyBazooka89)

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/ShrinkLongDescription.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/ShrinkLongDescription.java
@@ -56,6 +56,13 @@ public class ShrinkLongDescription
 		private static final int MAX_DEPTH = 10;
 		private static int depth = 0;
 
+		public static void Prefix(AbstractCard __instance)
+		{
+			if (depth == 0) {
+				Scale.descriptionScale.set(__instance, 1.0f);
+			}
+		}
+
 		public static void Postfix(AbstractCard __instance)
 		{
 			float descHeight = descriptionHeight(FontHelper.cardDescFont_N, __instance.description);


### PR DESCRIPTION
This is a fix to Shrink Long Description feature. After upgrading a card, the font size of description is incorrect.

![20190301223914_1](https://user-images.githubusercontent.com/43926043/53669616-f9216180-3c77-11e9-8bb8-de9b3a3a7155.jpg)

Before the fix:
![20190301223922_1](https://user-images.githubusercontent.com/43926043/53669620-fde61580-3c77-11e9-8a2b-33a379fc05b5.jpg)

After the fix:
![20190301224718_1](https://user-images.githubusercontent.com/43926043/53669623-01799c80-3c78-11e9-829e-611aee87d16f.jpg)