### PR TITLE
BaseMod 120 Locked Cards say Unknown instead of Locked

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/compendium/CardLibraryScreen/EverythingFix.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/compendium/CardLibraryScreen/EverythingFix.java
@@ -78,8 +78,7 @@ public class EverythingFix
 
                 AbstractCard.CardColor[] colors = AbstractCard.CardColor.values();
                 for (int icolor = AbstractCard.CardColor.CURSE.ordinal() + 1; icolor < colors.length; ++icolor) {
-                    CardGroup group = new CardGroup(CardGroup.CardGroupType.UNSPECIFIED);
-                    group.group = CardLibrary.getCardList(CardLibrary.LibraryType.valueOf(colors[icolor].name()));
+                    CardGroup group = Fields.cardGroupMap.get(colors[icolor]);
 
                     @SuppressWarnings("rawtypes")
                     Class[] cArg = new Class[1];


### PR DESCRIPTION
* Changing setLockStatus to reuse the cached CardGroups initialized earlier, instead of creating and editing new ones that are never saved.