### PR TITLE
Fix to [REMOVE_SPACE] feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -581,3 +581,4 @@ This is a fast forward to v1.6.3 of daviscook477's fork with a few additional ch
 
 #### dev ####
 * Fix energy tooltip rendering red orb under custom orb (kiooeht)
+* Fix to [REMOVE_SPACE] feature: commas, dots and similar should no longer go to the next line (JohnnyBazooka89)"

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/FontHelper/AllowSmartTextsToRemoveSpaces.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/FontHelper/AllowSmartTextsToRemoveSpaces.java
@@ -5,19 +5,14 @@ import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.evacipated.cardcrawl.modthespire.lib.*;
 import com.megacrit.cardcrawl.helpers.FontHelper;
-import javassist.CtBehavior;
+import javassist.*;
+import javassist.expr.ExprEditor;
+import javassist.expr.FieldAccess;
 
 import java.util.ArrayList;
 import java.util.List;
 
-// Note: This has a bug where words before and after the removed space can be split across lines
-// Example:
-// This is some text [REMOVE_SPACE]. More text.
-// Rendered:
-// This is some text
-// . More text.
-public class AllowSmartTextsToRemoveSpaces
-{
+public class AllowSmartTextsToRemoveSpaces {
 	public static final String REMOVE_SPACE_SPECIAL_KEYWORD = "[REMOVE_SPACE]";
 
 	@SpirePatch(
@@ -34,28 +29,29 @@ public class AllowSmartTextsToRemoveSpaces
 					Color.class
 			}
 	)
-	public static class RenderSmartTextPatch
-	{
+	public static class RenderSmartTextPatch {
 		public static boolean removeSpace = false;
+		public static boolean forceNotBreakingLine = false;
 
 		@SpireInsertPatch(
 				locator = RemoveSpecialWordLocator.class,
 				localvars = {"word"}
 		)
-		public static void InsertRemoveSpecialWord(SpriteBatch sb, BitmapFont font, String msg, float x, float y, float lineWidth, float lineSpacing, Color baseColor, @ByRef String[] word)
-		{
+		public static void InsertRemoveSpecialWord(SpriteBatch sb, BitmapFont font, String msg, float x, float y, float lineWidth, float lineSpacing, Color baseColor, @ByRef String[] word) {
 			removeSpace = false;
+			forceNotBreakingLine = false;
 			if (word[0].startsWith(REMOVE_SPACE_SPECIAL_KEYWORD)) {
 				word[0] = word[0].replace(REMOVE_SPACE_SPECIAL_KEYWORD, "");
 				removeSpace = true;
+				if (word[0].length() == 1) {
+					forceNotBreakingLine = true;
+				}
 			}
 		}
 
-		private static class RemoveSpecialWordLocator extends SpireInsertLocator
-		{
+		private static class RemoveSpecialWordLocator extends SpireInsertLocator {
 			@Override
-			public int[] Locate(CtBehavior method) throws Exception
-			{
+			public int[] Locate(CtBehavior method) throws Exception {
 				Matcher matcher = new Matcher.MethodCallMatcher(String.class, "equals");
 				return LineFinder.findInOrder(method, matcher);
 			}
@@ -65,23 +61,25 @@ public class AllowSmartTextsToRemoveSpaces
 				locator = RemoveSpaceLocator.class,
 				localvars = {"curWidth", "spaceWidth"}
 		)
-		public static void InsertRemoveSpace(SpriteBatch sb, BitmapFont font, String msg, float x, float y, float lineWidth, float lineSpacing, Color baseColor, @ByRef float[] curWidth, float spaceWidth)
-		{
+		public static void InsertRemoveSpace(SpriteBatch sb, BitmapFont font, String msg, float x, float y, float lineWidth, float lineSpacing, Color baseColor, @ByRef float[] curWidth, float spaceWidth) {
 			if (removeSpace) {
 				curWidth[0] -= spaceWidth;
 			}
 		}
 
-		private static class RemoveSpaceLocator extends SpireInsertLocator
-		{
+		private static class RemoveSpaceLocator extends SpireInsertLocator {
 			@Override
-			public int[] Locate(CtBehavior method) throws Exception
-			{
+			public int[] Locate(CtBehavior method) throws Exception {
 				Matcher matcher = new Matcher.MethodCallMatcher(BitmapFont.class, "draw");
 				List<Matcher> prereqs = new ArrayList<>();
 				prereqs.add(matcher);
 				return LineFinder.findInOrder(method, prereqs, matcher);
 			}
+		}
+
+		public static ExprEditor Instrument() throws CannotCompileException {
+			final int[] counter = {0};
+			return changeSecondLayoutWidthExprEditor(counter, RenderSmartTextPatch.class.getName());
 		}
 	}
 
@@ -95,27 +93,47 @@ public class AllowSmartTextsToRemoveSpaces
 					float.class
 			}
 	)
-	public static class GetSmartHeightPatch
-	{
+	public static class GetSmartHeightPatch {
+		public static boolean forceNotBreakingLine = false;
+
 		@SpireInsertPatch(
 				locator = RemoveSpecialWordLocator.class,
 				localvars = {"word"}
 		)
-		public static void Insert(BitmapFont font, String msg, float lineWidth, float lineSpacing, @ByRef String[] word)
-		{
+		public static void Insert(BitmapFont font, String msg, float lineWidth, float lineSpacing, @ByRef String[] word) {
+			forceNotBreakingLine = false;
 			if (word[0].startsWith(REMOVE_SPACE_SPECIAL_KEYWORD)) {
 				word[0] = word[0].replace(REMOVE_SPACE_SPECIAL_KEYWORD, "");
+				if (word[0].length() == 1) {
+					forceNotBreakingLine = true;
+				}
 			}
 		}
 
-		private static class RemoveSpecialWordLocator extends SpireInsertLocator
-		{
+		private static class RemoveSpecialWordLocator extends SpireInsertLocator {
 			@Override
-			public int[] Locate(CtBehavior method) throws Exception
-			{
+			public int[] Locate(CtBehavior method) throws Exception {
 				Matcher matcher = new Matcher.MethodCallMatcher(String.class, "equals");
 				return LineFinder.findInOrder(method, matcher);
 			}
 		}
+
+		public static ExprEditor Instrument() throws CannotCompileException {
+			final int[] counter = {0};
+			return changeSecondLayoutWidthExprEditor(counter, GetSmartHeightPatch.class.getName());
+		}
+	}
+
+	private static ExprEditor changeSecondLayoutWidthExprEditor(int[] counter, String className) {
+		return new ExprEditor() {
+			public void edit(FieldAccess f) throws CannotCompileException {
+				if (f.getFieldName().equals("width")) {
+					counter[0]++;
+					if (counter[0] == 2) {
+						f.replace("if(" + className + ".forceNotBreakingLine) $_ = 0.0F; else $_ = $proceed($$);");
+					}
+				}
+			}
+		};
 	}
 }


### PR DESCRIPTION
Fix to [REMOVE_SPACE] feature.

There was a known bug, when commas, dotc etc would go to the next line, like seen on these screenshots:
![1A_Before](https://user-images.githubusercontent.com/43926043/58441244-ae7d7d00-80e0-11e9-9ff4-fd106077bacb.jpg)
![2A_Before](https://user-images.githubusercontent.com/43926043/58441247-b0474080-80e0-11e9-9644-b54ad2d35e33.jpg)

After the fix, they should no longer go to the next line:
![1B_After](https://user-images.githubusercontent.com/43926043/58441249-b806e500-80e0-11e9-8a54-c6c873e0b612.jpg)
![2B_After](https://user-images.githubusercontent.com/43926043/58441250-b9d0a880-80e0-11e9-9342-12627a2cd90d.jpg)
