### PR TITLE
Add JavaFX dependency

### DIFF
--- a/mod/pom.xml
+++ b/mod/pom.xml
@@ -31,6 +31,11 @@
             <artifactId>Spriter</artifactId>
             <version>1.1</version>
         </dependency>
+            <dependency>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-controls</artifactId>
+                <version>13</version>
+            </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
I ran mvn install and I noticed that JavaFX was missing since BaseMod.java imports javafx.util.Pair .