### PR TITLE
Fix character name not visible in compendium for certain languages

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/mainMenu/ColorTabBar/ColorTabBarFix.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/mainMenu/ColorTabBar/ColorTabBarFix.java
@@ -156,7 +156,7 @@ public class ColorTabBarFix
                     }
                 }
                 String tabName = playerClass != null ? BaseMod.findCharacter(playerClass).getLocalizedCharacterName() : capitalizeWord(Fields.modTabs.get(i).color.toString());
-                FontHelper.renderFontCentered(sb, FontHelper.cardEnergyFont_L, tabName, 157.0f * Settings.scale, y - (SPACING * (i+1) * Settings.scale) + 50.0f * Settings.scale, textcolor, 0.6f);
+                FontHelper.renderFontCentered(sb, FontHelper.buttonLabelFont, tabName, 157.0f * Settings.scale, y - (SPACING * (i+1) * Settings.scale) + 50.0f * Settings.scale, textcolor, 0.85f);
             }
 
             for (int i = 0; i<Fields.modTabs.size(); ++i) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1008668/71590723-f67beb00-2b6c-11ea-9ce8-f8927cf9f957.png) -> ![image](https://user-images.githubusercontent.com/1008668/71590731-fb409f00-2b6c-11ea-8129-26fe261054fb.png)

In the beta branch, using `FontHelper.cardEnergyFont_L` (previously `FontHelper.bannerFont`) will make the character name invisible for some languages, including KOR and ZHS. Since they changed `ColorTabBar` to use `FontHelper.buttonLabelFont`, I think the same font should be used here.