### PR TITLE
Fix multiword keywords that use underscores.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -625,3 +625,4 @@ This is a fast forward to v1.6.3 of daviscook477's fork with a few additional ch
 * Fix custom boss map icons being black square if used a second time (kiooeht)
 * Fix boss map icons leaking memory (kiooeht)
 * Fix dynamic variables always rendering fully opaque (kiooeht)
+* Fix multiword keywords that use underscores (JohnnyBazooka89)

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/MultiwordKeywords.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/MultiwordKeywords.java
@@ -39,8 +39,8 @@ public class MultiwordKeywords
 			@Override
 			public int[] Locate(CtBehavior ctBehavior) throws Exception
 			{
-				Matcher matcher = new Matcher.MethodCallMatcher(ArrayList.class, "contains");
-				return LineFinder.findInOrder(ctBehavior, matcher);
+				Matcher matcher = new Matcher.MethodCallMatcher(StringBuilder.class, "append");
+				return new int[]{LineFinder.findAllInOrder(ctBehavior, matcher)[5]};
 			}
 		}
 	}


### PR DESCRIPTION
Before:
![obraz](https://user-images.githubusercontent.com/43926043/71792660-e0bd6880-3039-11ea-90e0-e78d630b6ab9.png)
After:
![aa](https://user-images.githubusercontent.com/43926043/71792665-e5821c80-3039-11ea-9d35-885a2417482a.png)
