### PR TITLE
Fix Relic Commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -636,3 +636,5 @@ This is a fast forward to v1.6.3 of daviscook477's fork with a few additional ch
 * Fix button positions on character select when using 4:3 resolution (kiooeht)
 * Display all characters on character select if only one modded character is loaded (kiooeht)
 * Hide long offscreen starter relic descriptions on character select (kiooeht)
+* Fix `relic add` command not showing Watcher only relics (JohnnyBazooka89)
+* Fix `relic list rare` command incorrectly showing boss relics (JohnnyBazooka89)

--- a/mod/src/main/java/basemod/BaseMod.java
+++ b/mod/src/main/java/basemod/BaseMod.java
@@ -1215,6 +1215,11 @@ public class BaseMod {
 		if (blueRelics != null) {
 			relicIDs.addAll(blueRelics.keySet());
 		}
+		HashMap<String, AbstractRelic> purpleRelics = (HashMap<String, AbstractRelic>) ReflectionHacks
+				.getPrivateStatic(RelicLibrary.class, "purpleRelics");
+		if (purpleRelics != null) {
+			relicIDs.addAll(purpleRelics.keySet());
+		}
 		if (getAllCustomRelics() != null) {
 			for (HashMap<String, AbstractRelic> e : getAllCustomRelics().values()) {
 				if (e != null) {

--- a/mod/src/main/java/basemod/devcommands/relic/RelicList.java
+++ b/mod/src/main/java/basemod/devcommands/relic/RelicList.java
@@ -34,6 +34,7 @@ public class RelicList extends ConsoleCommand {
             }
             case "rare": {
                 list = RelicLibrary.rareList;
+                break;
             }
             case "boss": {
                 list = RelicLibrary.bossList;


### PR DESCRIPTION
Fix `relic add` command not showing Watcher only relics

Before:
![Before 1](https://user-images.githubusercontent.com/43926043/72224519-c0326880-357b-11ea-9d2b-ec776d7c14e0.jpg)
After:
![After 1](https://user-images.githubusercontent.com/43926043/72224522-c7597680-357b-11ea-8448-c7d9845f568a.jpg)

Fix `relic list rare` command incorrectly showing boss relics

Before:
![Before 2](https://user-images.githubusercontent.com/43926043/72224529-d3ddcf00-357b-11ea-832f-d14aaf402ca4.jpg)
After:
![After 2](https://user-images.githubusercontent.com/43926043/72224533-d9d3b000-357b-11ea-8f96-eacf5ac23763.jpg)
