### PR TITLE
Added RewardScrolling patch from Hubris

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/CombatRewardScreen/RewardsScrolling.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/CombatRewardScreen/RewardsScrolling.java
@@ -45,7 +45,7 @@ public class RewardsScrolling
     {
         private static ScrollBar scrollBar = new ScrollBar(new ScrollListener(),
                 Settings.WIDTH / 2.0f + 270.0f * Settings.scale,
-                Settings.HEIGHT - 614.0f * Settings.scale,
+                Settings.HEIGHT / 2f - 86f * Settings.scale,
                 500 * Settings.scale);
         private static float scrollLowerBound = 0.0f;
         private static float scrollUpperBound = 0.0f;

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/CombatRewardScreen/RewardsScrolling.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/CombatRewardScreen/RewardsScrolling.java
@@ -27,10 +27,13 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Iterator;
 
-public class RewardsScrolling {
-    private static class ScrollListener implements ScrollBarListener {
+public class RewardsScrolling
+{
+    private static class ScrollListener implements ScrollBarListener
+    {
         @Override
-        public void scrolledUsingBar(float v) {
+        public void scrolledUsingBar(float v)
+        {
             Fields.scrollPosition = MathHelper.valueFromPercentBetween(Fields.scrollLowerBound, Fields.scrollUpperBound, v);
             Fields.scrollTarget = Fields.scrollPosition;
             AbstractDungeon.combatRewardScreen.positionRewards();
@@ -38,7 +41,8 @@ public class RewardsScrolling {
         }
     }
 
-    private static class Fields {
+    private static class Fields
+    {
         private static ScrollBar scrollBar = new ScrollBar(new ScrollListener(),
                 Settings.WIDTH / 2.0f + 270.0f * Settings.scale,
                 Settings.HEIGHT - 614.0f * Settings.scale,
@@ -52,9 +56,14 @@ public class RewardsScrolling {
         private static float grabStartY = 0.0f;
     }
 
-    @SpirePatch(clz = CombatRewardScreen.class, method = "setupItemReward")
-    public static class ResetScrollPosition {
-        public static void Prefix(CombatRewardScreen __instance) {
+    @SpirePatch(
+            clz = CombatRewardScreen.class,
+            method = "setupItemReward"
+    )
+    public static class ResetScrollPosition
+    {
+        public static void Prefix(CombatRewardScreen __instance)
+        {
             Fields.scrollPosition = 0.0f;
             Fields.scrollTarget = 0.0f;
 
@@ -63,12 +72,19 @@ public class RewardsScrolling {
         }
     }
 
-    @SpirePatch(clz = CombatRewardScreen.class, method = "renderItemReward")
-    public static class RenderScissor {
+    @SpirePatch(
+            clz = CombatRewardScreen.class,
+            method = "renderItemReward"
+    )
+    public static class RenderScissor
+    {
         private static OrthographicCamera camera = null;
 
-        @SpireInsertPatch(locator =  Locator.class)
-        public static void Insert(CombatRewardScreen __instance, SpriteBatch sb) {
+        @SpireInsertPatch(
+                locator = Locator.class
+        )
+        public static void Insert(CombatRewardScreen __instance, SpriteBatch sb)
+        {
             if (camera == null) {
                 try {
                     Field f = CardCrawlGame.class.getDeclaredField("camera");
@@ -88,7 +104,8 @@ public class RewardsScrolling {
             ScissorStack.pushScissors(scissors);
         }
 
-        public static void Postfix(CombatRewardScreen __instance, SpriteBatch sb) {
+        public static void Postfix(CombatRewardScreen __instance, SpriteBatch sb)
+        {
             if (camera != null) {
                 sb.flush();
                 ScissorStack.popScissors();
@@ -99,34 +116,46 @@ public class RewardsScrolling {
             }
         }
 
-        private static class Locator extends SpireInsertLocator {
-            public int[] Locate(CtBehavior ctMethodToPatch) throws CannotCompileException, PatchingException {
+        private static class Locator extends SpireInsertLocator
+        {
+            public int[] Locate(CtBehavior ctMethodToPatch) throws CannotCompileException, PatchingException
+            {
                 Matcher finalMatcher = new Matcher.FieldAccessMatcher(CombatRewardScreen.class, "rewards");
                 return LineFinder.findInOrder(ctMethodToPatch, new ArrayList<Matcher>(), finalMatcher);
             }
         }
     }
 
-    @SpirePatch(clz = CombatRewardScreen.class, method = "positionRewards")
-    public static class PositionRewards {
-        public static SpireReturn<Void> Prefix(CombatRewardScreen __instance) {
-                float baseY = Settings.HEIGHT - 410.0f * Settings.scale;
-                float spacingY = 100.0f * Settings.scale;
+    @SpirePatch(
+            clz = CombatRewardScreen.class,
+            method = "positionRewards"
+    )
+    public static class PositionRewards
+    {
+        public static SpireReturn<Void> Prefix(CombatRewardScreen __instance)
+        {
+            float baseY = Settings.HEIGHT - 410.0f * Settings.scale;
+            float spacingY = 100.0f * Settings.scale;
 
-                for (int i = 0; i < __instance.rewards.size(); ++i) {
-                    __instance.rewards.get(i).move(baseY - i * spacingY + Fields.scrollPosition);
-                }
-                if (__instance.rewards.isEmpty()) {
-                    __instance.hasTakenAll = true;
-                }
+            for (int i = 0; i < __instance.rewards.size(); ++i) {
+                __instance.rewards.get(i).move(baseY - i * spacingY + Fields.scrollPosition);
+            }
+            if (__instance.rewards.isEmpty()) {
+                __instance.hasTakenAll = true;
+            }
 
-                return SpireReturn.Return(null);
+            return SpireReturn.Return(null);
         }
     }
 
-    @SpirePatch(clz = CombatRewardScreen.class, method = "rewardViewUpdate")
-    public static class ScrollUpdate {
-        public static void Postfix(CombatRewardScreen __instance) {
+    @SpirePatch(
+            clz = CombatRewardScreen.class,
+            method = "rewardViewUpdate"
+    )
+    public static class ScrollUpdate
+    {
+        public static void Postfix(CombatRewardScreen __instance)
+        {
             if (__instance.rewards.size() < 6) {
                 Fields.scrollTarget = 0.0f;
                 Fields.scrollPosition = 0.0f;
@@ -175,15 +204,19 @@ public class RewardsScrolling {
             updateBarPosition();
         }
 
-        private static void updateBarPosition() {
+        private static void updateBarPosition()
+        {
             float percent = MathHelper.percentFromValueBetween(Fields.scrollLowerBound, Fields.scrollUpperBound, Fields.scrollPosition);
             Fields.scrollBar.parentScrolledToPercent(percent);
         }
 
-        public static ExprEditor Instrument() {
-            return new ExprEditor() {
+        public static ExprEditor Instrument()
+        {
+            return new ExprEditor()
+            {
                 @Override
-                public void edit(MethodCall m) throws CannotCompileException {
+                public void edit(MethodCall m) throws CannotCompileException
+                {
                     if (m.getClassName().equals(RewardItem.class.getName()) && m.getMethodName().equals("update")) {
                         m.replace("if (" + ScrollUpdate.class.getName() + ".DoUpdate($0)) {" +
                                 "$_ = $proceed($$);" +
@@ -193,7 +226,8 @@ public class RewardsScrolling {
             };
         }
 
-        public static boolean DoUpdate(RewardItem reward) {
+        public static boolean DoUpdate(RewardItem reward)
+        {
             boolean ret = false;
             if (reward.y < 800.0f * Settings.scale && reward.y > 200.0f * Settings.scale) {
                 ret = true;
@@ -245,7 +279,8 @@ public class RewardsScrolling {
             return ret;
         }
 
-        private static void moveRewardGlowEffect(RewardGlowEffect effect, float x, float y) {
+        private static void moveRewardGlowEffect(RewardGlowEffect effect, float x, float y)
+        {
             try {
                 Field f = RewardGlowEffect.class.getDeclaredField("x");
                 f.setAccessible(true);

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/CombatRewardScreen/RewardsScrolling.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/CombatRewardScreen/RewardsScrolling.java
@@ -229,7 +229,9 @@ public class RewardsScrolling
         public static boolean DoUpdate(RewardItem reward)
         {
             boolean ret = false;
-            if (reward.y < 800.0f * Settings.scale && reward.y > 200.0f * Settings.scale) {
+            float upperBounds = Settings.HEIGHT / 2f + 204f * Settings.scale;
+            float lowerBounds = Settings.HEIGHT / 2f + (124f - 460) * Settings.scale;
+            if (reward.y < upperBounds && reward.y > lowerBounds) {
                 ret = true;
             }
 

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/CombatRewardScreen/RewardsScrolling.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/CombatRewardScreen/RewardsScrolling.java
@@ -1,0 +1,262 @@
+package basemod.patches.com.megacrit.cardcrawl.screens.CombatRewardScreen;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.math.Rectangle;
+import com.badlogic.gdx.scenes.scene2d.utils.ScissorStack;
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.evacipated.cardcrawl.modthespire.patcher.PatchingException;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.helpers.MathHelper;
+import com.megacrit.cardcrawl.helpers.input.InputHelper;
+import com.megacrit.cardcrawl.rewards.RewardItem;
+import com.megacrit.cardcrawl.screens.CombatRewardScreen;
+import com.megacrit.cardcrawl.screens.mainMenu.ScrollBar;
+import com.megacrit.cardcrawl.screens.mainMenu.ScrollBarListener;
+import com.megacrit.cardcrawl.vfx.AbstractGameEffect;
+import com.megacrit.cardcrawl.vfx.RewardGlowEffect;
+import javassist.CannotCompileException;
+import javassist.CtBehavior;
+import javassist.expr.ExprEditor;
+import javassist.expr.MethodCall;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Iterator;
+
+public class RewardsScrolling {
+    private static class ScrollListener implements ScrollBarListener {
+        @Override
+        public void scrolledUsingBar(float v) {
+            Fields.scrollPosition = MathHelper.valueFromPercentBetween(Fields.scrollLowerBound, Fields.scrollUpperBound, v);
+            Fields.scrollTarget = Fields.scrollPosition;
+            AbstractDungeon.combatRewardScreen.positionRewards();
+            ScrollUpdate.updateBarPosition();
+        }
+    }
+
+    private static class Fields {
+        private static ScrollBar scrollBar = new ScrollBar(new ScrollListener(),
+                Settings.WIDTH / 2.0f + 270.0f * Settings.scale,
+                Settings.HEIGHT - 614.0f * Settings.scale,
+                500 * Settings.scale);
+        private static float scrollLowerBound = 0.0f;
+        private static float scrollUpperBound = 0.0f;
+        private static float scrollPosition = 0.0f;
+        private static float scrollTarget = 0.0f;
+
+        private static boolean grabbedScreen = false;
+        private static float grabStartY = 0.0f;
+    }
+
+    @SpirePatch(clz = CombatRewardScreen.class, method = "setupItemReward")
+    public static class ResetScrollPosition {
+        public static void Prefix(CombatRewardScreen __instance) {
+            Fields.scrollPosition = 0.0f;
+            Fields.scrollTarget = 0.0f;
+
+            Fields.grabbedScreen = false;
+            Fields.grabStartY = 0.0f;
+        }
+    }
+
+    @SpirePatch(clz = CombatRewardScreen.class, method = "renderItemReward")
+    public static class RenderScissor {
+        private static OrthographicCamera camera = null;
+
+        @SpireInsertPatch(locator =  Locator.class)
+        public static void Insert(CombatRewardScreen __instance, SpriteBatch sb) {
+            if (camera == null) {
+                try {
+                    Field f = CardCrawlGame.class.getDeclaredField("camera");
+                    f.setAccessible(true);
+                    camera = (OrthographicCamera) f.get(Gdx.app.getApplicationListener());
+                } catch (NoSuchFieldException | IllegalAccessException e) {
+                    e.printStackTrace();
+                    return;
+                }
+            }
+
+            sb.flush();
+            Rectangle scissors = new Rectangle();
+            Rectangle clipBounds = new Rectangle(Settings.WIDTH / 2.0f - 300 * Settings.scale, Settings.HEIGHT / 2.0f - 350 * Settings.scale,
+                    600 * Settings.scale, 600 * Settings.scale);
+            ScissorStack.calculateScissors(camera, sb.getTransformMatrix(), clipBounds, scissors);
+            ScissorStack.pushScissors(scissors);
+        }
+
+        public static void Postfix(CombatRewardScreen __instance, SpriteBatch sb) {
+            if (camera != null) {
+                sb.flush();
+                ScissorStack.popScissors();
+            }
+
+            if (__instance.rewards.size() > 5) {
+                Fields.scrollBar.render(sb);
+            }
+        }
+
+        private static class Locator extends SpireInsertLocator {
+            public int[] Locate(CtBehavior ctMethodToPatch) throws CannotCompileException, PatchingException {
+                Matcher finalMatcher = new Matcher.FieldAccessMatcher(CombatRewardScreen.class, "rewards");
+                return LineFinder.findInOrder(ctMethodToPatch, new ArrayList<Matcher>(), finalMatcher);
+            }
+        }
+    }
+
+    @SpirePatch(clz = CombatRewardScreen.class, method = "positionRewards")
+    public static class PositionRewards {
+        public static SpireReturn<Void> Prefix(CombatRewardScreen __instance) {
+                float baseY = Settings.HEIGHT - 410.0f * Settings.scale;
+                float spacingY = 100.0f * Settings.scale;
+
+                for (int i = 0; i < __instance.rewards.size(); ++i) {
+                    __instance.rewards.get(i).move(baseY - i * spacingY + Fields.scrollPosition);
+                }
+                if (__instance.rewards.isEmpty()) {
+                    __instance.hasTakenAll = true;
+                }
+
+                return SpireReturn.Return(null);
+        }
+    }
+
+    @SpirePatch(clz = CombatRewardScreen.class, method = "rewardViewUpdate")
+    public static class ScrollUpdate {
+        public static void Postfix(CombatRewardScreen __instance) {
+            if (__instance.rewards.size() < 6) {
+                Fields.scrollTarget = 0.0f;
+                Fields.scrollPosition = 0.0f;
+                __instance.positionRewards();
+                return;
+            }
+
+            if (Fields.scrollBar.update()) {
+                return;
+            }
+
+            int y = InputHelper.mY;
+            if (!Fields.grabbedScreen) {
+                if (InputHelper.scrolledDown) {
+                    Fields.scrollTarget += Settings.SCROLL_SPEED;
+                } else if (InputHelper.scrolledUp) {
+                    Fields.scrollTarget -= Settings.SCROLL_SPEED;
+                }
+
+                if (InputHelper.justClickedLeft) {
+                    Fields.grabbedScreen = true;
+                    Fields.grabStartY = y - Fields.scrollTarget;
+                }
+            } else if (InputHelper.isMouseDown) {
+                Fields.scrollTarget = y - Fields.grabStartY;
+            } else {
+                Fields.grabbedScreen = false;
+            }
+
+            float prev_scrollPosition = Fields.scrollTarget;
+            Fields.scrollPosition = MathHelper.scrollSnapLerpSpeed(Fields.scrollPosition, Fields.scrollTarget);
+
+            if (Fields.scrollTarget < 0) {
+                Fields.scrollTarget = 0.0f;
+            }
+
+            Fields.scrollUpperBound = (__instance.rewards.size() - 5) * 100.0f * Settings.scale;
+            if (Fields.scrollTarget > Fields.scrollUpperBound) {
+                Fields.scrollTarget = Fields.scrollUpperBound;
+            }
+
+            if (Fields.scrollPosition != prev_scrollPosition) {
+                __instance.positionRewards();
+            }
+
+            updateBarPosition();
+        }
+
+        private static void updateBarPosition() {
+            float percent = MathHelper.percentFromValueBetween(Fields.scrollLowerBound, Fields.scrollUpperBound, Fields.scrollPosition);
+            Fields.scrollBar.parentScrolledToPercent(percent);
+        }
+
+        public static ExprEditor Instrument() {
+            return new ExprEditor() {
+                @Override
+                public void edit(MethodCall m) throws CannotCompileException {
+                    if (m.getClassName().equals(RewardItem.class.getName()) && m.getMethodName().equals("update")) {
+                        m.replace("if (" + ScrollUpdate.class.getName() + ".DoUpdate($0)) {" +
+                                "$_ = $proceed($$);" +
+                                "}");
+                    }
+                }
+            };
+        }
+
+        public static boolean DoUpdate(RewardItem reward) {
+            boolean ret = false;
+            if (reward.y < 800.0f * Settings.scale && reward.y > 200.0f * Settings.scale) {
+                ret = true;
+            }
+
+            if (!ret) {
+                // Reset all the hitbox stuff to avoid weird behavior
+                reward.hb.hovered = false;
+                reward.hb.justHovered = false;
+                reward.hb.clicked = false;
+                reward.hb.clickStarted = false;
+
+                // Continue the flash timer to avoid flash desyncing them
+                if (reward.flashTimer > 0.0f) {
+                    reward.flashTimer -= Gdx.graphics.getDeltaTime();
+                    if (reward.flashTimer < 0.0f) {
+                        reward.flashTimer = 0.0f;
+                    }
+                }
+            }
+
+            try {
+                Field f = RewardItem.class.getDeclaredField("effects");
+                f.setAccessible(true);
+                ArrayList<AbstractGameEffect> effects = (ArrayList<AbstractGameEffect>) f.get(reward);
+
+                if (!ret) {
+                    // Continue glow effects to avoid desyncing them
+                    if (effects.size() == 0) {
+                        effects.add(new RewardGlowEffect(reward.hb.cX, reward.hb.cY));
+                    }
+                    for (Iterator<AbstractGameEffect> it = effects.iterator(); it.hasNext(); ) {
+                        AbstractGameEffect e = it.next();
+                        e.update();
+                        if (e.isDone) {
+                            it.remove();
+                        }
+                    }
+                }
+                for (AbstractGameEffect e : effects) {
+                    if (e instanceof RewardGlowEffect) {
+                        moveRewardGlowEffect((RewardGlowEffect) e, reward.hb.cX, reward.hb.cY);
+                    }
+                }
+            } catch (IllegalAccessException | NoSuchFieldException e) {
+                e.printStackTrace();
+            }
+
+            return ret;
+        }
+
+        private static void moveRewardGlowEffect(RewardGlowEffect effect, float x, float y) {
+            try {
+                Field f = RewardGlowEffect.class.getDeclaredField("x");
+                f.setAccessible(true);
+                f.setFloat(effect, x);
+
+                f = RewardGlowEffect.class.getDeclaredField("y");
+                f.setAccessible(true);
+                f.setFloat(effect, y);
+            } catch (IllegalAccessException | NoSuchFieldException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/CombatRewardScreen/RewardsScrolling.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/CombatRewardScreen/RewardsScrolling.java
@@ -134,7 +134,7 @@ public class RewardsScrolling
     {
         public static SpireReturn<Void> Prefix(CombatRewardScreen __instance)
         {
-            float baseY = Settings.HEIGHT - 410.0f * Settings.scale;
+            float baseY = Settings.HEIGHT / 2f + 124f * Settings.scale;
             float spacingY = 100.0f * Settings.scale;
 
             for (int i = 0; i < __instance.rewards.size(); ++i) {


### PR DESCRIPTION
Changed the rloc=20 patch to a FieldAccessMatcher-Locator

NOTE: I believe you could add a rewards > 5 check in:
` @SpirePatch(clz = CombatRewardScreen.class, method = "positionRewards")
    public static class PositionRewards {
        public static SpireReturn<Void> Prefix(CombatRewardScreen __instance) {`
so you don't overwrite the base game positioning when there's no need to. May help fix that bug that rtf50 and others have encountered.