### PR TITLE
Fix regression from 567bfca causing bias in boss selection rng

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -651,3 +651,4 @@ This is a fast forward to v1.6.3 of daviscook477's fork with a few additional ch
   * Meditate
   * Flicker (deprecated)
 * Fix many actions to work with max hand size changes (kiooeht)
+* Fix bias in boss selection RNG (dbjorge)


### PR DESCRIPTION
Per discussion in #modding discord, it looks like 567bfca introduced some unintentional bias into boss selection RNG in cases where there are no custom bosses being added by mods.

The issue is that with 567bfca in place, the sequence of events is:

* monsterRng is in state X
* base game's `<act>.initializeBoss()` adds the default 3 bosses and shuffles using monsterRng
* CustomBosses patch resets monsterRng to state X
* there are no custom bosses to add
* CustomBosses patch shuffles again (with monsterRng in the same state as the original shuffle)

This means that the list of 3 base game bosses is shuffled twice in a row using the same RNG each time. Shuffling twice using the same pattern does not result in a uniformly random shuffle; for starting state 1,2,3, the result of repeating exactly the same shuffle pattern twice results in a 2/3 chance of element 1 being first in the list. Practically speaking, this means that the first boss the base game act adds to the list is twice as likely to be chosen as it ought to be.

This PR reverts most of 567bfca and instead solves #229 by avoiding doing the second shuffle at all (and, thus, touching monsterRng at all) if there are no custom bosses to add. Per @ForgottenArbiter on Discord (who filed #229 in the first place), we don't think there's any value in monsterRng being stable compared the base game in the event that a mod is adding custom monsters to the boss pool, so we didn't think it was necessary to keep the RNG save/restore business for the sake of other monsterRng uses in cases that involve customized boss pools.