### PR TITLE
Fix Character Filter in the run history

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/runHistory/RunHistoryScreen/FixCharacterFilter.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/runHistory/RunHistoryScreen/FixCharacterFilter.java
@@ -94,20 +94,13 @@ public class FixCharacterFilter
 				characterFilterField.setAccessible(true);
 			
 				int selectedIndex = ((DropdownMenu) characterFilterField.get(__instance)).getSelectedIndex();
-				int index = 4; // start at index 4 b/c 0,1,2,3 are used by base game
-				if (selectedIndex < index) return; // don't need to filter if base game handled the filter
-				
-				AbstractPlayer.PlayerClass compareTo = null;
-				for (AbstractPlayer character : BaseMod.getModdedCharacters()) {
-					if (selectedIndex == index) {
-						compareTo = character.chosenClass;
-						break;
+
+				if (selectedIndex > 0) {
+					AbstractPlayer.PlayerClass compareTo = CardCrawlGame.characterManager.getAllCharacters().get(selectedIndex - 1).chosenClass;
+					if (compareTo != null) {
+						String runCharacter = data.character_chosen;
+						includeMe[0] = includeMe[0] && (runCharacter.equals(compareTo.name()));
 					}
-					index++;
-				}
-				if (compareTo != null) {
-					String runCharacter = data.character_chosen;
-					includeMe[0] = includeMe[0] && (runCharacter.equals(compareTo.name()));
 				}
 			} catch (Exception e) {
 				logger.error("unable to filter characters on run history screen");


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1008668/74497834-05064200-4f22-11ea-8dbb-f577a4fc71e9.png)
![image](https://user-images.githubusercontent.com/1008668/74497840-07689c00-4f22-11ea-818d-39561a8059b3.png)



The character filter in the run history screen works incorrectly. Specifically,

- It says 'No run histories are found' if you choose the Watcher.
- If you have custom characters loaded, they are shifted by one. If you select the last character in the list, it works as same as 'All Characters'

This happens because the patch for the filter assumes there are only 3 base game characters. This PR fixes that.

The patch also uses `rloc`, but I'm not sure how to fix it so I left it in.