### PR TITLE
Clear RoomEventDialog

### DIFF
--- a/mod/src/main/java/basemod/devcommands/event/Event.java
+++ b/mod/src/main/java/basemod/devcommands/event/Event.java
@@ -7,6 +7,7 @@ import basemod.DevConsole;
 import basemod.ReflectionHacks;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.events.AbstractImageEvent;
+import com.megacrit.cardcrawl.events.RoomEventDialog;
 import com.megacrit.cardcrawl.helpers.EventHelper;
 import com.megacrit.cardcrawl.localization.EventStrings;
 import com.megacrit.cardcrawl.localization.LocalizedStrings;
@@ -46,6 +47,8 @@ public class Event extends ConsoleCommand {
             DevConsole.log(eventName + " is not an event ID");
             return;
         }
+        
+        RoomEventDialog.optionList.clear();
 
         AbstractDungeon.eventList.add(0, eventName);
 


### PR DESCRIPTION
When using the Event command, due to RoomEventDialog holding options in a static variable, the initialization of certain events done in the 
if (EventHelper.getEvent(eventName) == null)
test causes duplicated options to occur.
As such, this clears RoomEventDialog's option list before the event is instantiated again.