### PR TITLE
Fix scrolling tooltips in single-card view omitting some tips when many exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -662,3 +662,4 @@ This is a fast forward to v1.6.3 of daviscook477's fork with a few additional ch
 * Fix duplicate options when using event command (Alchyr)
 
 #### dev ####
+* Fix scrolling tooltips in single-card view omitting some tips when many exist


### PR DESCRIPTION
This is a fix for https://github.com/dbjorge/jorbs-spire-mod/issues/434: cards with many keyword tooltips only show some of the tooltips in the scrolling tooltip view provided by BaseMod.

The root cause is that `TipHelper.renderPowerTips` has some of its own behavior for handling large numbers of tips (presumably added after the basemod functionality?) that tries to fix the issue by offsetting some of the tips into a second column. BaseMod's `ScrollingTooltips` patch assumes that all the rendered tips will be in sequence in one column and uses `ScissorStack` to prevent rendering of any tips outside the first column, so functionally, it just doesn't render any tips that `TipHelper` offsets.

This patch works around that issue by telling `TipHelper` that `Settings.HEIGHT` is an arbitrary huge number when the `ScrollingTooltips` behavior is in play, such that it never thinks it's run out of vertical space (and thus never needs to wrap/offset any tips).

Before:
![Anmerkung 2020-02-21 173930](https://user-images.githubusercontent.com/32041265/75053273-43c36b80-54d1-11ea-9667-ca1581f91ae9.png)

After:
![image](https://user-images.githubusercontent.com/376284/75646953-2fcde700-5c00-11ea-830a-d6f9f36050c2.png)

Verified also that this doesn't break the normal offsetting behavior when the scrolling is not in play (ie, hovering the character model when the character has many powers)
