### PR TITLE
readme: put `desktop-1.0.jar` in `lib`, not `_lib`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ BaseMod provides a number of hooks and a console.
 
 ## Building ##
 1. (If you haven't already) `mvn install` ModTheSpire Altenatively, modify pom.xml to point to a local copy of the JAR.
-2. Copy `desktop-1.0.jar` from your Slay the Spire folder into `../_lib` relative to the repo.
+2. Copy `desktop-1.0.jar` from your Slay the Spire folder into `../lib` relative to the repo.
 3. Run `mvn package`
 
 ## Installation ##


### PR DESCRIPTION
Following the instructions as previously written, `mvn package` threw
an error:

    Could not find artifact com.megacrit.cardcrawl:slaythespire:jar:01-27-2020 at specified path /PATH/TO/BaseMod/mod/../../lib/desktop-1.0.jar

Putting the jarfile in `lib` instead of `_lib` fixed the problem for me.

wchargin-branch: readme-lib-dir