### PR TITLE
Only grant extra orb slots to modded characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -688,3 +688,4 @@ This is a fast forward to v1.6.3 of daviscook477's fork with a few additional ch
 
 #### dev ####
 * Color tiny cards in Run History for modded cards (kiooeht)
+* For non-modded characters, don't give any extra orb slots on channel (wchargin)

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/characters/AbstractPlayer/GiveOrbSlotOnChannel.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/characters/AbstractPlayer/GiveOrbSlotOnChannel.java
@@ -1,5 +1,6 @@
 package basemod.patches.com.megacrit.cardcrawl.characters.AbstractPlayer;
 
+import basemod.BaseMod;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.orbs.AbstractOrb;
@@ -12,6 +13,12 @@ public class GiveOrbSlotOnChannel
 {
 	public static void Prefix(AbstractPlayer __instance, AbstractOrb orbToSet)
 	{
+		// For modded characters, grant an orb slot when channeling to facilitate cross-class card
+		// generation. For official characters, do nothing, to avoid changing the behavior of the
+		// base game (via Watcher's Foreign Influence, the Note for Yourself event, etc.).
+		if (BaseMod.isBaseGameCharacter(__instance)) {
+			return;
+		}
 		if (__instance.masterMaxOrbs == 0 && __instance.maxOrbs == 0) {
 			__instance.masterMaxOrbs = 1;
 			__instance.increaseMaxOrbSlots(1, true);


### PR DESCRIPTION
BaseMod includes a patch to give the player an extra orb slot when they
channel an orb but their (master) character has no orb slots. This is
intended to make it easier for mods to take advantage of cross-class
card generation, but since the introduction of the Watcher it has a
significant effect on the base game: Foreign Influence can give cards
that generate orbs, but, unlike Prismatic Shard, does not itself give an
orb slot. Thus, with BaseMod, a Watcher run could benefit from passive
and active effects of orbs, and could also receive a focus debuff from
the Spire Shield; neither of these would happen with only the base game.

(Even before Watcher, this was observably different due to the Note for
Yourself event, but that’s a bit more niche since the event only occurs
at some ascension levels.)

This commit changes the orb-slot patch to only apply to modded
characters, restoring the original behavior for official characters.
This is beneficial for people who use BaseMod only for cosmetic mods,
like the Colored Map mod, the Googly Eyes mod, or the Slay the Relics
exporter.

Alternative approaches considered:

 1. Remove the patch entirely. This would be a breaking change for a
    bunch of mods, so is probably not viable.
 2. Add a user-facing setting, like the one for the dev console. This
    makes it easy for users to flip this setting without realizing it,
    accidentally breaking their mods. We probably want to avoid letting
    users shoot themselves in the foot if we can help it.
 3. Let the behavior of the patch be controlled by a static global, and
    create a separate “Restore vanilla channel behavior” mod that just
    flips the setting. This is effectively the same as approach (2), but
    makes the setting more deliberate. Any compatibility issues would be
    in familiar terrain, as users understand that not all mods are
    compatible with each other. But it would require someone to maintain
    this new “flag flip” mod, and it would add some cruft onto the
    BaseMod API.

Test Plan:
Start a run of the Watcher, and use Foreign Influence to give yourself
an orb-generating card like Cold Snap. Play it, and note that no orb is
channeled and the standard “no orb slots” message appears:

![Screenshot after playing Cold Snap on Watcher][ss-watcher]

Then, load up a TestMod run, and note that playing Cold Snap *does*
actually channel the orb:

![Screenshot after playing Cold Snap on Purpleclad (TestMod)][ss-mod]

[ss-watcher]: https://user-images.githubusercontent.com/4317806/79933605-5f7dbc00-8405-11ea-90ad-970b543e4d2e.png
[ss-mod]: https://user-images.githubusercontent.com/4317806/79933619-673d6080-8405-11ea-8ea8-61f785f1dfdd.png

wchargin-branch: extra-orb-slot-mod-only

