### PR TITLE
Event Override Default Functionality

### DIFF
--- a/mod/src/main/java/basemod/eventUtil/EventUtils.java
+++ b/mod/src/main/java/basemod/eventUtil/EventUtils.java
@@ -85,21 +85,7 @@ public class EventUtils {
                 spawnCondition,
                 actIDs == null ? new String[]{} : actIDs);
 
-        if (type == EventType.OVERRIDE && overrideEvent != null) {
-            c.overrideEvent = overrideEvent;
-
-            if (!overrideEvents.containsKey(overrideEvent)) {
-                overrideEvents.put(overrideEvent, new ArrayList<>());
-            }
-            overrideEvents.get(overrideEvent).add(c);
-
-            eventLogger.info("Override event " + c + " for event " + overrideEvent + " registered. " + c.getConditions());
-
-            if (bonusCondition != null) {
-                overrideBonusConditions.put(c, bonusCondition);
-                eventLogger.info("  This event has a bonus condition.");
-            }
-        } else if (type == EventType.FULL_REPLACE && overrideEvent != null) {
+        if (type == EventType.FULL_REPLACE && overrideEvent != null) {
             c.overrideEvent = ID;
 
             if (!fullReplaceEventList.containsKey(overrideEvent)) {
@@ -113,6 +99,20 @@ public class EventUtils {
             if (bonusCondition != null) {
                 normalEventBonusConditions.put(ID, bonusCondition);
                 specialEventBonusConditions.put(ID, bonusCondition);
+                eventLogger.info("  This event has a bonus condition.");
+            }
+        } else if (overrideEvent != null) { // type == EventType.OVERRIDE && 
+            c.overrideEvent = overrideEvent;
+
+            if (!overrideEvents.containsKey(overrideEvent)) {
+                overrideEvents.put(overrideEvent, new ArrayList<>());
+            }
+            overrideEvents.get(overrideEvent).add(c);
+
+            eventLogger.info("Override event " + c + " for event " + overrideEvent + " registered. " + c.getConditions());
+
+            if (bonusCondition != null) {
+                overrideBonusConditions.put(c, bonusCondition);
                 eventLogger.info("  This event has a bonus condition.");
             }
         } else if (type == EventType.ONE_TIME) {


### PR DESCRIPTION
Currently, AddEventParams will have a type of NORMAL if it isn't specified, so if an override event is specified but type is not, it will not override the event at all. This will cause it to default to an OVERRIDE event if type is unspecified but an override event is.