### PR TITLE
Allow upgrade count 0 in Hand and Deck command

### DIFF
--- a/mod/src/main/java/basemod/devcommands/deck/DeckAdd.java
+++ b/mod/src/main/java/basemod/devcommands/deck/DeckAdd.java
@@ -26,7 +26,7 @@ public class DeckAdd extends DeckManipulator {
         if (c != null) {
             // card count
             int count = 1;
-            if (tokens.length > countIndex + 1 && ConvertHelper.tryParseInt(tokens[countIndex + 1], 0) != 0) {
+            if (tokens.length > countIndex + 1 && ConvertHelper.tryParseInt(tokens[countIndex + 1]) != null) {
                 count = ConvertHelper.tryParseInt(tokens[countIndex + 1], 0);
             }
 

--- a/mod/src/main/java/basemod/devcommands/deck/DeckManipulator.java
+++ b/mod/src/main/java/basemod/devcommands/deck/DeckManipulator.java
@@ -30,7 +30,7 @@ public abstract class DeckManipulator extends ConsoleCommand {
 
     protected int countIndex(String[] tokens) {
         int countIndex = tokens.length - 1;
-        while (ConvertHelper.tryParseInt(tokens[countIndex], 0) != 0) {
+        while (ConvertHelper.tryParseInt(tokens[countIndex]) != null) {
             countIndex--;
         }
         return countIndex;

--- a/mod/src/main/java/basemod/devcommands/hand/Hand.java
+++ b/mod/src/main/java/basemod/devcommands/hand/Hand.java
@@ -29,7 +29,7 @@ public class Hand extends ConsoleCommand {
 
     public static int countIndex(String[] tokens) {
         int countIndex = tokens.length - 1;
-        while (ConvertHelper.tryParseInt(tokens[countIndex], 0) != 0) {
+        while (ConvertHelper.tryParseInt(tokens[countIndex]) != null) {
             countIndex--;
         }
         return countIndex;

--- a/mod/src/main/java/basemod/devcommands/hand/HandAdd.java
+++ b/mod/src/main/java/basemod/devcommands/hand/HandAdd.java
@@ -25,7 +25,7 @@ public class HandAdd extends ConsoleCommand {
         if (c != null) {
             // card count
             int count = 1;
-            if (tokens.length > countIndex + 1 && ConvertHelper.tryParseInt(tokens[countIndex + 1], 0) != 0) {
+            if (tokens.length > countIndex + 1 && ConvertHelper.tryParseInt(tokens[countIndex + 1]) != null) {
                 count = ConvertHelper.tryParseInt(tokens[countIndex + 1], 0);
             }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1008668/82728304-85f78580-9d2a-11ea-9eb8-b5f119267293.png)
(This is the fixed image)

Currently, if you write `hand add PiercingWail 1 0` it fails because of some weird method of parsing tokens. This PR fixes that so you get non-upgraded cards in your hand/deck.