### PR TITLE
Fix ZHS, ZHT, JPN not displaying color in tooltips

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/FontHelper/FixChineseNoColoredText.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/helpers/FontHelper/FixChineseNoColoredText.java
@@ -1,0 +1,41 @@
+package basemod.patches.com.megacrit.cardcrawl.helpers.FontHelper;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.megacrit.cardcrawl.helpers.FontHelper;
+import javassist.CtBehavior;
+
+@SpirePatch(
+		clz = FontHelper.class,
+		method = "exampleNonWordWrappedText"
+)
+public class FixChineseNoColoredText {
+	@SpireInsertPatch(
+			locator = Locator.class,
+			localvars = {"word"}
+	)
+	public static void Insert(SpriteBatch sb, BitmapFont font, String msg, float x, float y, Color c, float widthMax, float lineSpacing, @ByRef float[] ___curWidth, @ByRef int[] ___currentLine, String word) {
+		if (word.length() > 1 && word.charAt(1) == '#') {
+			FontHelper.layout.setText(font, word);
+			___curWidth[0] += FontHelper.layout.width;
+			if (___curWidth[0] > widthMax) {
+				___curWidth[0] = 0.0F;
+				++___currentLine[0];
+				font.draw(sb, word, x + ___curWidth[0], y - lineSpacing * ___currentLine[0]);
+				___curWidth[0] = FontHelper.layout.width;
+			} else {
+				font.draw(sb, word, x + ___curWidth[0] - FontHelper.layout.width, y - lineSpacing * ___currentLine[0]);
+			}
+		}
+	}
+
+	private static class Locator extends SpireInsertLocator {
+		@Override
+		public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
+			Matcher finalMatcher = new Matcher.MethodCallMatcher(FontHelper.class, "identifyOrb");
+			return LineFinder.findInOrder(ctMethodToPatch, finalMatcher);
+		}
+	}
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1008668/97437444-d07acf00-1966-11eb-80bc-05699c9af299.png) => ![image](https://user-images.githubusercontent.com/1008668/97437454-d375bf80-1966-11eb-96f9-2494b3eb046d.png)

The above shows the tooltip of Crystal Ball relic from the mystic mod. The ZHS description of Crystal Ball is as follows: 
`所有非 [#FF5252]战技牌[] 的技能牌视作 [#5299E0]法术牌[] ，所有非 [#5299E0]法术牌[] 的攻击牌视作 [#FF5252]战技牌[] 。`

Currently in ZHS, ZHT or JPN, if you use [#FF5252]word[] to color a word in smart text, the word is not displayed at all. This PR fixes that.
