### PR TITLE
Fix Unnecessary Reward Culling

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/rooms/AbstractRoom/FixUnnecessaryRewardCulling.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/rooms/AbstractRoom/FixUnnecessaryRewardCulling.java
@@ -1,0 +1,25 @@
+package basemod.patches.com.megacrit.cardcrawl.rooms.AbstractRoom;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireInstrumentPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.rooms.AbstractRoom;
+import javassist.CannotCompileException;
+import javassist.expr.ExprEditor;
+import javassist.expr.MethodCall;
+
+import java.util.ArrayList;
+
+@SpirePatch(clz = AbstractRoom.class, method = "addPotionToRewards", paramtypez = {})
+public class FixUnnecessaryRewardCulling {
+    @SpireInstrumentPatch
+    public static ExprEditor patch() {
+        return new ExprEditor() {
+            @Override
+            public void edit(MethodCall m) throws CannotCompileException {
+                if (m.getClassName().equals(ArrayList.class.getName()) && m.getMethodName().equals("size")) {
+                    m.replace("$_ = -1;");
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
If there are 4 or more rewards the base game prevents potions from spawning (even with WBS), this fixes that by replacing the call to rewards.size() with a return of -1