### PR TITLE
Fix custom reward render

### DIFF
--- a/mod/src/main/java/basemod/CustomCharacterSelectScreen.java
+++ b/mod/src/main/java/basemod/CustomCharacterSelectScreen.java
@@ -96,6 +96,16 @@ public class CustomCharacterSelectScreen extends CharacterSelectScreen {
             );
         }
 
+        leftArrow.move(
+                offsetX - 220.0F * Settings.scale,
+                (Settings.isFourByThree ? 254.0F : 190.0F) * Settings.scale
+        );
+
+        rightArrow.move(
+                offsetX + (float)count * 220.0F * Settings.scale,
+                (Settings.isFourByThree ? 254.0F : 190.0F) * Settings.scale
+        );
+
     }
 
     private void setCurrentOptions(boolean rightClicked){
@@ -137,6 +147,12 @@ public class CustomCharacterSelectScreen extends CharacterSelectScreen {
             this.w = (int)(Settings.scale * arrow.getWidth());
             this.h = (int)(Settings.scale * arrow.getHeight());
             this.hitbox = new Hitbox(x,y,w,h);
+        }
+
+        public void move(float newX, float newY) {
+            x = (int) (newX - w / 2f);
+            y = (int) (newY - h / 2f);
+            hitbox.move(newX, newY);
         }
 
         @Override
@@ -185,6 +201,12 @@ public class CustomCharacterSelectScreen extends CharacterSelectScreen {
             this.w = (int)(Settings.scale * arrow.getWidth());
             this.h = (int)(Settings.scale * arrow.getHeight());
             this.hitbox = new Hitbox(x,y,w,h);
+        }
+
+        public void move(float newX, float newY) {
+            x = (int) (newX - w / 2f);
+            y = (int) (newY - h / 2f);
+            hitbox.move(newX, newY);
         }
 
         @Override

--- a/mod/src/main/java/basemod/abstracts/CustomReward.java
+++ b/mod/src/main/java/basemod/abstracts/CustomReward.java
@@ -88,9 +88,9 @@ public abstract class CustomReward extends RewardItem
 		}
 
 		if (this.hb.clickStarted) {
-			sb.draw(ImageMaster.REWARD_SCREEN_ITEM, Settings.WIDTH / 2.0f - 232.0f, this.y - 49.0f, 232.0f, 49.0f, 464.0f, 98.0f, Settings.scale * 0.98f, Settings.scale * 0.98f, 0.0f, 0, 0, 464, 98, false, false);
+			sb.draw(ImageMaster.REWARD_SCREEN_ITEM, Settings.WIDTH / 2.0f - 232.0f, this.y - 49.0f, 232.0f, 49.0f, 464.0f, 98.0f, Settings.xScale * 0.98f, Settings.scale * 0.98f, 0.0f, 0, 0, 464, 98, false, false);
 		} else {
-			sb.draw(ImageMaster.REWARD_SCREEN_ITEM, Settings.WIDTH / 2.0f - 232.0f, this.y - 49.0f, 232.0f, 49.0f, 464.0f, 98.0f, Settings.scale, Settings.scale, 0.0f, 0, 0, 464, 98, false, false);
+			sb.draw(ImageMaster.REWARD_SCREEN_ITEM, Settings.WIDTH / 2.0f - 232.0f, this.y - 49.0f, 232.0f, 49.0f, 464.0f, 98.0f, Settings.xScale, Settings.scale, 0.0f, 0, 0, 464, 98, false, false);
 		}
 
 		if (this.flashTimer != 0.0f) {
@@ -109,7 +109,7 @@ public abstract class CustomReward extends RewardItem
 			c = Settings.GOLD_COLOR.cpy();
 		}
 
-		FontHelper.renderSmartText(sb, FontHelper.cardDescFont_N, this.text, 833.0f * Settings.scale, this.y + 5.0f * Settings.scale, 1000.0f * Settings.scale, 0.0f, c);
+		FontHelper.renderSmartText(sb, FontHelper.cardDescFont_N, this.text, Settings.WIDTH * 0.434F, this.y + 5.0f * Settings.scale, 1000.0f * Settings.scale, 0.0f, c);
 
 		if (!this.hb.hovered) {
 			for (AbstractGameEffect e : this.effects) {


### PR DESCRIPTION
Hi!

This PR is to fix the rendering of custom rewards, and the character select left and right arrows on ultra-wide resolutions. I think the devs made some tweaks for the new resolution settings in the recent update.

Current version
![image](https://user-images.githubusercontent.com/2972834/103570395-424f2780-4e86-11eb-9fc9-fcf79ace2811.png)
![image](https://user-images.githubusercontent.com/2972834/103570459-5bf06f00-4e86-11eb-863c-a1f65e74548e.png)


Fixed version
![image](https://user-images.githubusercontent.com/2972834/103570434-5004ad00-4e86-11eb-89d2-06b493112bf8.png)
![image](https://user-images.githubusercontent.com/2972834/103570614-ab369f80-4e86-11eb-8630-460b6c4addab.png)
