### PR TITLE
I thought there would me more to do for this change

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/CardModifierPatches.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/CardModifierPatches.java
@@ -296,7 +296,7 @@ public class CardModifierPatches
             @Override
             public int[] Locate(CtBehavior ctMethodToPatch) throws Exception
             {
-                Matcher finalMatcher = new Matcher.FieldAccessMatcher(AbstractCard.class, "timesUpgraded");
+                Matcher finalMatcher = new Matcher.FieldAccessMatcher(AbstractCard.class, "name");
                 return LineFinder.findInOrder(ctMethodToPatch, finalMatcher);
             }
         }


### PR DESCRIPTION
makes cardmodifiers copy to newly copied cards *after* upgrades are applied instead of before, to fix situations like echoform+ having an ethereal mod, and the copied card upgrading to remove it after cardmods apply