### PR TITLE
fix all onUse related hooks to not trigger when unplayable and autoplayed

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/CardModifierPatches.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/CardModifierPatches.java
@@ -421,8 +421,8 @@ public class CardModifierPatches
                 locator = Locator.class
         )
         public static void Insert(UseCardAction __instance, AbstractCard card, AbstractCreature target) {
-            CardModifierManager.onUseCard(card, target, __instance);
             if (!card.dontTriggerOnUseCard) {
+                CardModifierManager.onUseCard(card, target, __instance);
                 AbstractPlayer p = AbstractDungeon.player;
                 for (AbstractCard c : p.hand.group) {
                     if (c != card) {
@@ -435,8 +435,8 @@ public class CardModifierPatches
                 for (AbstractCard c : p.discardPile.group) {
                     CardModifierManager.onOtherCardPlayed(c, card, p.discardPile);
                 }
+                CardModifierManager.removeWhenPlayedModifiers(card);
             }
-            CardModifierManager.removeWhenPlayedModifiers(card);
         }
 
         private static class Locator extends SpireInsertLocator


### PR DESCRIPTION
Fixes a niche bug where a card that has been given extra effects by cardmods, but is unplayable, will still trigger those effects when autoplayed by things like mayhem