### PR TITLE
single card view width of variable with additional character

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderCustomDynamicVariable.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderCustomDynamicVariable.java
@@ -119,6 +119,7 @@ public class RenderCustomDynamicVariable
                         start_x - current_x + gl.width + 10.0f * Settings.scale,
                         i * 1.53f * -font.getCapHeight() + draw_y - current_y + -12.0f,
                         0.0f, true, Settings.CREAM_COLOR);
+                stringBuilder.append(end);
             }
             stringBuilder.append(' ');
             gl.setText(font, stringBuilder.toString());


### PR DESCRIPTION
Technically this is also incorrect for normal variables, but I can't write that patch right now because I don't have basemod set up for editing where I am, and also in my projects I only use this with custom variables