### PR TITLE
Crash fix for cardPlayable outside of combat

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/CardGroup/CardPlayableMonsterNullCrashFix.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/CardGroup/CardPlayableMonsterNullCrashFix.java
@@ -1,0 +1,25 @@
+package basemod.patches.com.megacrit.cardcrawl.cards.CardGroup;
+
+import basemod.BaseMod;
+import com.evacipated.cardcrawl.modthespire.Loader;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch2;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePrefixPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpireReturn;
+import com.megacrit.cardcrawl.cards.CardGroup;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+
+//Under certain circumstances CardGroup:RefreshHandLayout is called when the player is out of combat which causes a crash when glowCheck calls c.triggerOnGlowCheck() which calls c.canUse() which calls c.cardPlayable(m) whose if statement crashes if monsters is null
+@SpirePatch2(clz = CardGroup.class, method = "glowCheck")
+public class CardPlayableMonsterNullCrashFix {
+    @SpirePrefixPatch
+    public static SpireReturn<Void> patch() {
+        if(AbstractDungeon.getMonsters() == null) {
+            if(Loader.DEBUG) {
+                BaseMod.logger.warn("cardPlayable crash has been averted.");
+            }
+            return SpireReturn.Return();
+        }
+
+        return SpireReturn.Continue();
+    }
+}


### PR DESCRIPTION
Due to some strange reason, refreshHandLayout is called outside of combat sometimes if you're going through it too quickly and under other circumstances.

RefreshHandLayout -> glowCheck -> triggerOnGlowCheck -> canUse -> cardPlayable

cardPlayable's if statement 
if (((this.target == CardTarget.ENEMY || this.target == CardTarget.SELF_AND_ENEMY) && m != null && m.isDying) || AbstractDungeon.getMonsters().areMonstersBasicallyDead()) {

crashes outside of combat since getCurrRoom().monsters is null.


To fix this, a simple prefix spirereturn is applied to glowCheck that ends the chain if monsters == null