### PR TITLE
fix custom mode mods sometimes persisting between runs (issue #271)

### DIFF
--- a/mod/src/main/java/basemod/BaseMod.java
+++ b/mod/src/main/java/basemod/BaseMod.java
@@ -46,6 +46,7 @@ import com.megacrit.cardcrawl.characters.AbstractPlayer.PlayerClass;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.daily.mods.AbstractDailyMod;
 import com.megacrit.cardcrawl.daily.mods.RedCards;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.events.AbstractEvent;
@@ -2649,6 +2650,10 @@ public class BaseMod {
 	public static void publishAddCustomModeMods(List<CustomMod> modList) {
 		logger.info("publishAddCustomModeMods");
 
+		String modType = "legacy"; 	//if community consensus thinks character card mods should be available on the daily, change this to "generic"
+									//maybe make this into a config? Idk that's out of this fix's scope.
+		HashMap<String, AbstractDailyMod> map = ReflectionHacks.getPrivateStatic(ModHelper.class, modType + "Mods");
+
 		CustomMod charMod = new CustomMod("Modded Character Cards", "p", false);
 		for (AbstractPlayer character : getModdedCharacters()) {
 			CustomMod mod = new CustomMod(RedCards.ID, "g", true);
@@ -2661,6 +2666,11 @@ public class BaseMod {
 			ReflectionHacks.setPrivate(mod, CustomMod.class, "height", height);
 
 			insertCustomMod(modList, mod);
+
+			if (map != null) {
+				AbstractDailyMod dailyMod = new AbstractDailyMod(mod.ID, mod.name, mod.description, "diverse.png", true, character.chosenClass);
+				map.put(dailyMod.modID, dailyMod);
+			}
 		}
 
 		for (AddCustomModeModsSubscriber sub : addCustomModeModsSubscribers) {

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/dungeons/AbstractDungeon/InitializeCardPoolsSwitch.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/dungeons/AbstractDungeon/InitializeCardPoolsSwitch.java
@@ -34,10 +34,6 @@ public class InitializeCardPoolsSwitch {
 		AbstractPlayer player = AbstractDungeon.player;
 		AbstractPlayer.PlayerClass chosenClass = player.chosenClass;
 
-		if (AbstractPlayer.customMods == null) {
-			AbstractPlayer.customMods = new ArrayList<>();
-		}
-
 		// Diverse
 		if (ModHelper.isModEnabled(Diverse.ID)) {
 			for (AbstractPlayer character : BaseMod.getModdedCharacters()) {
@@ -45,16 +41,16 @@ public class InitializeCardPoolsSwitch {
 			}
 		} else if (!BaseMod.isBaseGameCharacter(chosenClass)) {
 			// Red/Green/Blue/Purple Cards modifiers for modded characters
-			if (AbstractPlayer.customMods.contains(RedCards.ID)) {
+			if (ModHelper.isModEnabled(RedCards.ID)) {
 				CardLibrary.addRedCards(tmpPool);
 			}
-			if (AbstractPlayer.customMods.contains(GreenCards.ID)) {
+			if (ModHelper.isModEnabled(GreenCards.ID)) {
 				CardLibrary.addGreenCards(tmpPool);
 			}
-			if (AbstractPlayer.customMods.contains(BlueCards.ID)) {
+			if (ModHelper.isModEnabled(BlueCards.ID)) {
 				CardLibrary.addBlueCards(tmpPool);
 			}
-			if (AbstractPlayer.customMods.contains(PurpleCards.ID)) {
+			if (ModHelper.isModEnabled(PurpleCards.ID)) {
 				CardLibrary.addPurpleCards(tmpPool);
 			}
 		}
@@ -67,7 +63,7 @@ public class InitializeCardPoolsSwitch {
 					continue;
 				}
 				 String ID = character.chosenClass.name() + charMod.name;
-				 if (AbstractPlayer.customMods.contains(ID)) {
+				 if (ModHelper.isModEnabled(ID)) {
 				 	BaseMod.logger.info("[INFO] Adding " + character.getLocalizedCharacterName() + " cards into card pool.");
 				 	AbstractCard.CardColor color = character.getCardColor();
 				 	for (AbstractCard c : CardLibrary.cards.values()) {


### PR DESCRIPTION
When a custom mode run is started with any modded character's "character cards" or a modded character run is started with any "character cards" mod, then abandoned, the mod will still count as active when a new non-custom mode run is started during the same runtime. This aims to fix it by using the proper ModHelper call, as well as defining those custom mode mods as proper Dailys