### PR TITLE
Feature: Dynamic Text Blocks

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/DynamicTextBlocks.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/DynamicTextBlocks.java
@@ -13,24 +13,23 @@ import javassist.expr.ExprEditor;
 import javassist.expr.MethodCall;
 import org.apache.commons.lang3.math.NumberUtils;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 
 public class DynamicTextBlocks {
-    private static final String REGEX = "\\{!.*?!\\|.*?}"; //"(\\[!.*?!\\|).*?(\\|])"
+    private static final String REGEX = "\\{!.*?!\\|.*?}";
     private static final String DYNAMIC_KEY = "{@@}";
     private static final Pattern PATTERN = Pattern.compile(REGEX);
 
-    //TODO: make this all less inefficient
+    //TODO: Efficiency improvements?
 
-    //Spire Field for fixing the !L! var in ExhaustPileViewScreen thanks to the fact it returns a copy of the card that isnt actually in the Exhaust pile when you pull up the screen...
+    //Spire Field for fixing the Location var in ExhaustPileViewScreen thanks to the fact it returns a copy of the card that isn't actually in the Exhaust pile when you pull up the screen
     @SpirePatch(clz= AbstractCard.class, method=SpirePatch.CLASS)
     private static class ExhaustViewFixField {
         public static final SpireField<Boolean> exhaustViewCopy = new SpireField<>(() -> Boolean.FALSE);
     }
 
-    //Spire Field for if dynamic text was found. This allows faster checking since we dont need to regex each time
+    //Spire Field for if dynamic text was found. This allows faster checking since we don't need to regex each time
     @SpirePatch(clz= AbstractCard.class, method=SpirePatch.CLASS)
     private static class DynamicTextField {
         public static final SpireField<Boolean> isDynamic = new SpireField<>(() -> Boolean.FALSE);
@@ -81,7 +80,7 @@ public class DynamicTextBlocks {
         }
     }
 
-    //Force an !L! update when a card is exhausted.
+    //Force a Location update when a card is exhausted.
     @SpirePatch(clz = CardGroup.class, method = "moveToExhaustPile")
     public static class UpdateTextOnExhaust{
         @SpirePostfixPatch()
@@ -153,18 +152,18 @@ public class DynamicTextBlocks {
                 } else if (AbstractDungeon.player.discardPile.contains(c)) {
                     var = 2;
                 } else if (AbstractDungeon.player.exhaustPile.contains(c) || ExhaustViewFixField.exhaustViewCopy.get(c)) {
-                    //This is where we need the field. Without it this will default back to -1 as the cards shown in the Exhaust View are copies that arent actually in the exhaust pile
+                    //This is where we need the field. Without it this will default back to -1 as the cards shown in the Exhaust View are copies that aren't actually in the exhaust pile
                     var = 3;
                 }
             }
         } else if (parts[0].equals("!Upgrades!")) {
-            //Used to grab the amount of times the card was upgraded. Again, isnt a real dynvar
+            //Used to grab the amount of times the card was upgraded. Again, isn't a real dynvar
             var = c.timesUpgraded;
         } else if (BaseMod.cardDynamicVariableMap.containsKey(parts[0].replace("!",""))) {
             //Check to see if it's a recognized dynvar registered by some mod
             var = BaseMod.cardDynamicVariableMap.get(parts[0].replace("!","")).value(c);
         }
-        //Clean up the first string since we dont need it
+        //Clean up the first string since we don't need it
         parts = Arrays.copyOfRange(parts, 1, parts.length);
         //If we found a var then we can do stuff, else just return an empty string
         if (var != null) {
@@ -172,14 +171,14 @@ public class DynamicTextBlocks {
             boolean matched = false;
             //Iterate each case. Note that the right most matching case will be the output string, or the default output if no cases match
             for (String s : parts) {
-                //All cases need to contain a single =, which we use to split the case into its values and output
+                //All cases need to contain a single =, which we use for splitting the case into its values and output
                 if (s.contains("=")) {
                     String[] split = s.split("=");
                     //Check if the condition has commas, an indicator of a case having multiple conditions.
                     if (split[0].contains(",")) {
-                        String[] nums = split[0].split(",");
+                        String[] numbers = split[0].split(",");
                         //Iterate each condition, as long as at least 1 condition matches we set the text
-                        for (String n : nums) {
+                        for (String n : numbers) {
                             if(checkMatch(var, n)) {
                                 //Checking the length allows up to know if there is actual text or just an empty string
                                 if (split.length > 1) {
@@ -201,7 +200,7 @@ public class DynamicTextBlocks {
                             matched = true;
                         }
                     }
-                    //If this is the default output designated by @= then set this as the output text if we havent matched anything else yet.
+                    //If this is the default output designated by @= then set this as the output text if we haven't matched anything else yet.
                     if (split[0].equals("@") && !matched) {
                         if (split.length > 1) {
                             key = split[1];
@@ -237,7 +236,7 @@ public class DynamicTextBlocks {
             //As long as at least one condition matches we are good
             return signCheck || moduloCheck || digitCheck;
         }
-        //If its not a creatable number, there was a format error. Just return false instead of blowing up
+        //If it's not a creatable number, there was a format error. Just return false instead of blowing up
         return false;
     }
 }

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/DynamicTextBlocks.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/DynamicTextBlocks.java
@@ -166,6 +166,7 @@ public class DynamicTextBlocks {
         //Clean up the first string since we don't need it
         parts = Arrays.copyOfRange(parts, 1, parts.length);
         //If we found a var then we can do stuff, else just return an empty string
+        key = "";
         if (var != null) {
             //Define a matched flag. Lets us know to NOT overwrite the output string with the default output if it actually matched a case
             boolean matched = false;
@@ -210,8 +211,6 @@ public class DynamicTextBlocks {
                     }
                 }
             }
-        } else {
-            key = "";
         }
         return key;
     }

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/DynamicTextBlocks.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/DynamicTextBlocks.java
@@ -138,7 +138,7 @@ public class DynamicTextBlocks {
                 var = c.block;
             } else if (parts[0].equals("!M!")) {
                 var = c.magicNumber;
-            } else if (parts[0].equals("!L!")) {
+            } else if (parts[0].equals("!Location!")) {
                 //Used to grab the location of the card. Isn't a real dynvar, but we can pretend =]
                 var = -1; //Master Deck, Compendium, Limbo, modded CardGroups
                 if (CardCrawlGame.dungeon != null && AbstractDungeon.player != null) {
@@ -153,6 +153,9 @@ public class DynamicTextBlocks {
                         var = 3;
                     }
                 }
+            } else if (parts[0].equals("!Upgrades!")) {
+                //Used to grab the amount of times the card was upgraded. Again, isnt a real dynvar
+                var = c.timesUpgraded;
             } else if (BaseMod.cardDynamicVariableMap.containsKey(parts[0].replace("!",""))) {
                 //Check to see if it's a recognized dynvar registered by some mod
                 var = BaseMod.cardDynamicVariableMap.get(parts[0].replace("!","")).value(c);

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/DynamicTextBlocks.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/DynamicTextBlocks.java
@@ -1,0 +1,161 @@
+package basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard;
+
+import basemod.BaseMod;
+import com.evacipated.cardcrawl.modthespire.lib.SpireInstrumentPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import javassist.CannotCompileException;
+import javassist.expr.ExprEditor;
+import javassist.expr.MethodCall;
+import org.apache.commons.lang3.math.NumberUtils;
+
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+
+public class DynamicTextBlocks {
+
+    //TODO: |@@], |@@@] recursive check for nested text, terminal string (ends with xyz)
+
+
+    @SpirePatch(clz = AbstractCard.class, method = "initializeDescription")
+    @SpirePatch(clz = AbstractCard.class, method = "initializeDescriptionCN")
+    public static class BeDifferentColorPls {
+        @SpireInstrumentPatch
+        public static ExprEditor patch() {
+            return new ExprEditor() {
+                @Override
+                //Method call is basically the equivalent of a methodcallmatcher of an insert patch, checks the edit method against every method call in the function you#re patching
+                public void edit(MethodCall m) throws CannotCompileException {
+                    //If the method is from the class AnimationState and the method is called update
+                    if (m.getClassName().equals(String.class.getName()) && m.getMethodName().equals("split")) {
+                        m.replace("{ $_ = " + basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard.DynamicTextBlocks.class.getName()+".checkForUnwrapping(this, $proceed($$), 1); }");
+                    }
+                }
+            };
+        }
+    }
+
+    public static String[] checkForUnwrapping(AbstractCard c, String[] splitText, int layer) {
+        String baseText = String.join(" ", splitText);
+        String regex = makeRegex(layer);
+        if (baseText.matches(regex)) {
+            String temp = baseText.replaceAll(regex,"@temp@");
+            ArrayList<String> toUnwrap = new ArrayList<>();
+            Pattern p = Pattern.compile(regex);
+            java.util.regex.Matcher m = p.matcher(baseText);
+            while (m.find()) {
+                toUnwrap.add(unwrap(c, m.group(), layer));
+            }
+            while (!toUnwrap.isEmpty()){
+                temp = temp.replaceFirst("@temp@", toUnwrap.get(0));
+                toUnwrap.remove(0);
+            }
+            return checkForUnwrapping(c, temp.split(" "), layer + 1);
+        } else {
+            return baseText.split(" ");
+        }
+    }
+
+    public static String makeRegex(int layers) {
+        StringBuilder s = new StringBuilder(".*(\\[!.*?!\\|).*?(\\|");
+        for (int i = 0 ; i < layers ; i ++) {
+            s.append("@");
+        }
+        s.append("]).*");
+        return s.toString();
+    }
+
+    public static int getCustomLocation(AbstractCard c) {
+        return -1;
+    }
+
+    public static String unwrap(AbstractCard c, String string, int layer) {
+        if (string.length() > 0 && string.charAt(0) == '[') {
+            String key = string.trim();
+            if (key.endsWith("@]")) {
+                key = key.replace("*d", "D").replace("*b", "B").replace("*m", "M");
+            }
+            key = key.substring(1, key.length()-2-layer);
+            String[] parts = key.split("\\|");
+            Integer var = null;
+            if (parts[0].equals("!D!")) {
+                var = c.damage;
+            } else if (parts[0].equals("!B!")) {
+                var = c.block;
+            } else if (parts[0].equals("!M!")) {
+                var = c.magicNumber;
+            } else if (parts[0].equals("!L!")) {
+                if (CardCrawlGame.dungeon == null || AbstractDungeon.player == null){
+                    var = -1;
+                } else if (AbstractDungeon.player.hand.contains(c)) {
+                    var = 0;
+                } else if (AbstractDungeon.player.drawPile.contains(c)) {
+                    var = 1;
+                } else if (AbstractDungeon.player.discardPile.contains(c)) {
+                    var = 2;
+                } else if (AbstractDungeon.player.exhaustPile.contains(c)) {
+                    var = 3;
+                } else {
+                    var = getCustomLocation(c);
+                }
+            } else if (BaseMod.cardDynamicVariableMap.containsKey(parts[0].replace("!",""))) {
+                var = BaseMod.cardDynamicVariableMap.get(parts[0].replace("!","")).value(c);
+            }
+            parts[0] = "";
+            if (var != null) {
+                boolean matched = false;
+                for (String s : parts) {
+                    if (s.contains("=")) {
+                        String[] split = s.split("=");
+                        if (split[0].contains(",")) {
+                            String[] nums = split[0].split(",");
+                            for (String n : nums) {
+                                if(checkMatch(var, n)) {
+                                    if (split.length > 1) {
+                                        string = split[1];
+                                    } else {
+                                        string = "";
+                                    }
+                                    matched = true;
+                                }
+                            }
+                        } else {
+                            if (checkMatch(var, split[0])) {
+                                if (split.length > 1) {
+                                    string = split[1];
+                                } else {
+                                    string = "";
+                                }
+                                matched = true;
+                            }
+                        }
+                        if (split[0].equals("@") && !matched) {
+                            if (split.length > 1) {
+                                string = split[1];
+                            } else {
+                                string = "";
+                            }
+                        }
+                    }
+                }
+            } else {
+                string = "";
+            }
+        }
+        return string;
+    }
+
+    private static boolean checkMatch(Integer var, String s) {
+        boolean greater = s.contains(">");
+        boolean less = s.contains("<");
+        boolean mod = s.contains("%");
+        s = s.replace(">", "").replace("<", "").replace("%", "");
+        if (NumberUtils.isCreatable(s)) {
+            int comp = var.compareTo(NumberUtils.createInteger(s));
+            return ((!greater && !less && comp == 0) || (greater && comp > 0) || (less && comp < 0) || (mod && comp == 0) || (mod && (var % NumberUtils.createInteger(s) == 0)));
+        }
+        return false;
+    }
+}

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/DynamicTextBlocks.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/DynamicTextBlocks.java
@@ -1,27 +1,54 @@
 package basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard;
 
 import basemod.BaseMod;
-import com.evacipated.cardcrawl.modthespire.lib.SpireInstrumentPatch;
-import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
-import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
+import com.evacipated.cardcrawl.modthespire.lib.*;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.screens.ExhaustPileViewScreen;
 import javassist.CannotCompileException;
+import javassist.CtBehavior;
 import javassist.expr.ExprEditor;
 import javassist.expr.MethodCall;
 import org.apache.commons.lang3.math.NumberUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.regex.Pattern;
 
 public class DynamicTextBlocks {
 
     //TODO: make this all less inefficient
 
+    //Spire Field for fixing the !L! var in ExhaustPileViewScreen thanks to the fact it returns a copy of the card that isnt actually in the Exhaust pile when you pull up the screen...
+    @SpirePatch(clz= AbstractCard.class, method=SpirePatch.CLASS)
+    private static class ExhaustViewFixField {
+        public static final SpireField<Boolean> exhaustViewCopy = new SpireField<>(() -> Boolean.FALSE);
+    }
+
+    //When we render said card copy, set its field and initialize description
+    @SpirePatch(clz = ExhaustPileViewScreen.class, method = "open")
+    public static class FixExhaustText {
+        @SpireInsertPatch(locator = Locator.class, localvars = "toAdd")
+        public static void setField(ExhaustPileViewScreen __instance, AbstractCard toAdd) {
+            ExhaustViewFixField.exhaustViewCopy.set(toAdd, true);
+            toAdd.initializeDescription();
+        }
+
+        private static class Locator extends SpireInsertLocator {
+            @Override
+            public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
+                Matcher finalMatcher = new Matcher.MethodCallMatcher(CardGroup.class, "addToBottom");
+                return LineFinder.findInOrder(ctMethodToPatch, finalMatcher);
+            }
+        }
+    }
+
+    //Allows dynamic text to work with powers while in your hand and when targeting enemies
     @SpirePatch(clz = AbstractCard.class, method = "applyPowers")
     @SpirePatch(clz = AbstractCard.class, method = "calculateCardDamage")
-    public static class AutoupdateText {
+    public static class UpdateTextForPowers {
         @SpirePostfixPatch
         public static void updateAfterVarChange(AbstractCard __instance) {
             if (__instance.rawDescription.matches(".*(\\[!.*?!\\|).*?(\\|]).*")) {
@@ -30,6 +57,27 @@ public class DynamicTextBlocks {
         }
     }
 
+    //Allows !L! to set its location properly by forcing an update when the deck is initialized at the start of combat
+    @SpirePatch(clz = CardGroup.class, method = "initializeDeck")
+    public static class UpdateTextOnDeckCreation {
+        @SpirePostfixPatch()
+        public static void updateAfterAdding(CardGroup __instance, CardGroup masterDeck) {
+            for (AbstractCard c : __instance.group) {
+                c.initializeDescription();
+            }
+        }
+    }
+
+    //Force an !L! update when a card is exhausted.
+    @SpirePatch(clz = CardGroup.class, method = "moveToExhaustPile")
+    public static class UpdateTextOnExhaust{
+        @SpirePostfixPatch()
+        public static void updateAfter(CardGroup __instance, AbstractCard c) {
+            c.initializeDescription();
+        }
+    }
+
+    //Patch to take place in for the foreach loop. Takes place after card mod patch
     @SpirePatch(clz = AbstractCard.class, method = "initializeDescription")
     @SpirePatch(clz = AbstractCard.class, method = "initializeDescriptionCN")
     public static class ProcessDynamicText {
@@ -37,9 +85,7 @@ public class DynamicTextBlocks {
         public static ExprEditor patch() {
             return new ExprEditor() {
                 @Override
-                //Method call is basically the equivalent of a methodcallmatcher of an insert patch, checks the edit method against every method call in the function you#re patching
                 public void edit(MethodCall m) throws CannotCompileException {
-                    //If the method is from the class AnimationState and the method is called update
                     if (m.getClassName().equals(String.class.getName()) && m.getMethodName().equals("split")) {
                         m.replace("{ $_ = " + basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard.DynamicTextBlocks.class.getName()+".checkForUnwrapping(this, $proceed($$)); }");
                     }
@@ -49,67 +95,86 @@ public class DynamicTextBlocks {
     }
 
     public static String[] checkForUnwrapping(AbstractCard c, String[] splitText) {
+        //Rejoin the text that has since been split into works
         String baseText = String.join(" ", splitText);
         String regex = "(\\[!.*?!\\|).*?(\\|])";
+        //If the string contains the regex, we need to unpack it
         if (baseText.matches(".*"+regex+".*")) {
+            //Replace all the dynamic text blocks with @temp@ for now
             String temp = baseText.replaceAll(regex,"@temp@");
+            //Make an array to hold the dynamic text pieces from the main text string
             ArrayList<String> toUnwrap = new ArrayList<>();
             Pattern p = Pattern.compile(regex);
             java.util.regex.Matcher m = p.matcher(baseText);
             while (m.find()) {
                 toUnwrap.add(unwrap(c, m.group()));
             }
+            //Once all the unwrapping is done, replace the @temp@ pieces with our new strings
             while (!toUnwrap.isEmpty()){
                 temp = temp.replaceFirst("@temp@", toUnwrap.get(0));
                 toUnwrap.remove(0);
             }
+            //Return our unpacked string
             return temp.split(" ");
         } else {
+            //Else just return the re-split string as normal
             return baseText.split(" ");
         }
     }
 
     public static String unwrap(AbstractCard c, String string) {
+        //TODO redundant check
         if (string.length() > 0 && string.charAt(0) == '[') {
             String key = string.trim();
-            if (key.endsWith("@]")) {
-                key = key.replace("*d", "D").replace("*b", "B").replace("*m", "M");
-            }
+            //Cut the leading [ and the trailing |] and then split the string along each |
             key = key.substring(1, key.length()-2);
             String[] parts = key.split("\\|");
+            //Our first piece will always be the dynamic variable we care about. Find its value
             Integer var = null;
             if (parts[0].equals("!D!")) {
+                //Uses !D! for damage, just like normal dynvars, same applies to !B! and !M!
                 var = c.damage;
             } else if (parts[0].equals("!B!")) {
                 var = c.block;
             } else if (parts[0].equals("!M!")) {
                 var = c.magicNumber;
             } else if (parts[0].equals("!L!")) {
-                var = -1;
-                if (CardCrawlGame.dungeon != null && AbstractDungeon.player != null){
+                //Used to grab the location of the card. Isn't a real dynvar, but we can pretend =]
+                var = -1; //Master Deck, Compendium, Limbo, modded CardGroups
+                if (CardCrawlGame.dungeon != null && AbstractDungeon.player != null) {
                     if (AbstractDungeon.player.hand.contains(c)) {
                         var = 0;
                     } else if (AbstractDungeon.player.drawPile.contains(c)) {
                         var = 1;
                     } else if (AbstractDungeon.player.discardPile.contains(c)) {
                         var = 2;
-                    } else if (AbstractDungeon.player.exhaustPile.contains(c)) {
+                    } else if (AbstractDungeon.player.exhaustPile.contains(c) || ExhaustViewFixField.exhaustViewCopy.get(c)) {
+                        //This is where we need the field. Without it this will default back to -1 as the cards shown in the Exhaust View are copies that arent actually in the exhaust pile
                         var = 3;
                     }
                 }
             } else if (BaseMod.cardDynamicVariableMap.containsKey(parts[0].replace("!",""))) {
+                //Check to see if it's a recognized dynvar registered by some mod
                 var = BaseMod.cardDynamicVariableMap.get(parts[0].replace("!","")).value(c);
             }
-            parts[0] = "";
+            //Clean up the first string since we dont need it
+            parts = Arrays.copyOfRange(parts, 1, parts.length);
+            //If we found a var then we can do stuff, else just return an empty string
             if (var != null) {
+                //Define a matched flag. Lets us know to NOT overwrite the output string with the default output if it actually matched a case
                 boolean matched = false;
+                //Iterate each case. Note that the right most matching case will be the output string, or the default output if no cases match
                 for (String s : parts) {
+                    //All cases need to contain a single =, which we use to split the case into its values and output
                     if (s.contains("=")) {
                         String[] split = s.split("=");
+                        //Check if the condition has commas, an indicator of a case having multiple conditions.
                         if (split[0].contains(",")) {
                             String[] nums = split[0].split(",");
+                            //Iterate each condition, as long as at least 1 condition matches we set the text
                             for (String n : nums) {
                                 if(checkMatch(var, n)) {
+                                    //Checking the length allows up to know if there is actual text of just an empty string
                                     if (split.length > 1) {
                                         string = split[1];
                                     } else {
@@ -119,6 +184,7 @@ public class DynamicTextBlocks {
                                 }
                             }
                         } else {
+                            //Else just check the condition directly
                             if (checkMatch(var, split[0])) {
                                 if (split.length > 1) {
                                     string = split[1];
@@ -128,6 +194,7 @@ public class DynamicTextBlocks {
                                 matched = true;
                             }
                         }
+                        //If this is the default output designated by @= then set this as the output text if we havent matched anything else yet.
                         if (split[0].equals("@") && !matched) {
                             if (split.length > 1) {
                                 string = split[1];
@@ -145,21 +212,23 @@ public class DynamicTextBlocks {
     }
 
     private static boolean checkMatch(Integer var, String s) {
+        //Greater Than, Less Than, Divisible By, and Ends With are the 4 supported conditional checks, in addition to Direct Match, which has no symbol attached
         boolean greater = s.contains(">");
         boolean less = s.contains("<");
         boolean mod = s.contains("%");
         boolean ends = s.contains("&");
+        //Remove all these special symbols before checking if the condition is a number we can make
         s = s.replace(">", "").replace("<", "").replace("%", "").replace("&","");
         if (NumberUtils.isCreatable(s)) {
+            //Grab our var minus the number, helpful for comparisons
             int comp = var.compareTo(NumberUtils.createInteger(s));
-            if (ends) {
-                int len = s.length();
-                return comp == 0 || comp % Math.pow(10, len) == 0;
-            }
-            if (mod) {
-                return comp == 0 || var % NumberUtils.createInteger(s) == 0;
-            }
-            return ((!greater && !less && comp == 0) || (greater && comp > 0) || (less && comp < 0));
+            //Checks the Direct Match, Greater Than, and Less Than cases
+            boolean signCheck = !greater && !less && comp == 0 || greater && comp > 0 || less && comp < 0;
+            //Checks the Divisible By case. If the numbers are equal (comp is 0), or if variable mod check is 0, then its divisible
+            boolean moduloCheck = mod && (comp == 0 || var % NumberUtils.createInteger(s) == 0);
+            //Checks the Ends With case. If the numbers are equal, or if the trailing digits of comp are all 0's, then var ends with condition
+            boolean digitCheck = ends && (comp == 0 || comp % Math.pow(10, s.length()) == 0);
+            return signCheck || moduloCheck || digitCheck;
         }
         return false;
     }


### PR DESCRIPTION
Adds support for Dynamic Text Blocks on cards to help with pluralization cases for translators. Cards with descriptions containing the key {@@} will be parsed for pluralization cases. Dynamic Text can also be added via Card Mods.
Example:
{@@}Deal !D! damage. NL Draw !M! card{!M!|>1=s}.