### PR TITLE
Add StartPlayerTurnHook and StartPlayerTurnPostDrawHook

### DIFF
--- a/mod/src/main/java/basemod/BaseMod.java
+++ b/mod/src/main/java/basemod/BaseMod.java
@@ -156,6 +156,8 @@ public class BaseMod {
 	private static ArrayList<OnPlayerLoseBlockSubscriber> onPlayerLoseBlockSubscribers;
 	private static ArrayList<OnPlayerDamagedSubscriber> onPlayerDamagedSubscribers;
 	private static ArrayList<OnCreateDescriptionSubscriber> onCreateDescriptionSubscribers;
+	private static ArrayList<StartPlayerTurnSubscriber> startPlayerTurnSubscribers;
+	private static ArrayList<StartPlayerTurnPostDrawSubscriber> startPlayerTurnPostDrawSubscribers;
 
 	private static ArrayList<AbstractCard> redToAdd;
 	private static ArrayList<String> redToRemove;
@@ -481,6 +483,8 @@ public class BaseMod {
 		onPlayerLoseBlockSubscribers = new ArrayList<>();
 		onPlayerDamagedSubscribers = new ArrayList<>();
 		onCreateDescriptionSubscribers = new ArrayList<>();
+		startPlayerTurnSubscribers = new ArrayList<>();
+		startPlayerTurnPostDrawSubscribers = new ArrayList<>();
 	}
 
 	// initializeCardLists -
@@ -2745,6 +2749,26 @@ public class BaseMod {
 		return rawDescription;
 	}
 
+	public static void publishStartPlayerTurn(int turn) {
+		logger.info("publishStartPlayerTurn turn = " + turn);
+
+		for (StartPlayerTurnSubscriber sub : startPlayerTurnSubscribers) {
+			sub.receiveStartPlayerTurn(turn);
+		}
+
+		unsubscribeLaterHelper(OnCreateDescriptionSubscriber.class);
+	}
+
+	public static void publishStartPlayerTurnPostDraw(int turn) {
+		logger.info("publishStartPlayerTurnPostDraw turn = " + turn);
+
+		for (StartPlayerTurnPostDrawSubscriber sub : startPlayerTurnPostDrawSubscribers) {
+			sub.receiveStartPlayerTurnPostDraw(turn);
+		}
+
+		unsubscribeLaterHelper(OnCreateDescriptionSubscriber.class);
+	}
+
 	//
 	// Subscription handlers
 	//
@@ -2820,6 +2844,8 @@ public class BaseMod {
 		subscribeIfInstance(onPlayerLoseBlockSubscribers, sub, OnPlayerLoseBlockSubscriber.class);
 		subscribeIfInstance(onPlayerDamagedSubscribers, sub, OnPlayerDamagedSubscriber.class);
 		subscribeIfInstance(onCreateDescriptionSubscribers, sub, OnCreateDescriptionSubscriber.class);
+		subscribeIfInstance(startPlayerTurnSubscribers, sub, StartPlayerTurnSubscriber.class);
+		subscribeIfInstance(startPlayerTurnPostDrawSubscribers, sub, StartPlayerTurnPostDrawSubscriber.class);
 	}
 
 	// subscribe -
@@ -2917,6 +2943,10 @@ public class BaseMod {
 			onPlayerDamagedSubscribers.add((OnPlayerDamagedSubscriber) sub);
 		} else if (additionClass.equals(OnCreateDescriptionSubscriber.class)) {
 			onCreateDescriptionSubscribers.add((OnCreateDescriptionSubscriber) sub);
+		} else if (additionClass.equals(StartPlayerTurnSubscriber.class)) {
+			startPlayerTurnSubscribers.add((StartPlayerTurnSubscriber) sub);
+		} else if (additionClass.equals(StartPlayerTurnPostDrawSubscriber.class)) {
+			startPlayerTurnPostDrawSubscribers.add((StartPlayerTurnPostDrawSubscriber) sub);
 		}
 	}
 
@@ -2969,6 +2999,8 @@ public class BaseMod {
 		unsubscribeIfInstance(onPlayerLoseBlockSubscribers, sub, OnPlayerLoseBlockSubscriber.class);
 		unsubscribeIfInstance(onPlayerDamagedSubscribers, sub, OnPlayerDamagedSubscriber.class);
 		unsubscribeIfInstance(onCreateDescriptionSubscribers, sub, OnCreateDescriptionSubscriber.class);
+		unsubscribeIfInstance(startPlayerTurnSubscribers, sub, StartPlayerTurnSubscriber.class);
+		unsubscribeIfInstance(startPlayerTurnPostDrawSubscribers, sub, StartPlayerTurnPostDrawSubscriber.class);
 	}
 
 	// unsubscribe -
@@ -3068,6 +3100,10 @@ public class BaseMod {
 			onPlayerDamagedSubscribers.remove(sub);
 		} else if (removalClass.equals(OnCreateDescriptionSubscriber.class)) {
 			onCreateDescriptionSubscribers.remove(sub);
+		} else if (removalClass.equals(StartPlayerTurnSubscriber.class)) {
+			startPlayerTurnSubscribers.remove(sub);
+		} else if (removalClass.equals(StartPlayerTurnPostDrawSubscriber.class)) {
+			startPlayerTurnPostDrawSubscribers.remove(sub);
 		}
 	}
 

--- a/mod/src/main/java/basemod/interfaces/StartPlayerTurnPostDrawSubscriber.java
+++ b/mod/src/main/java/basemod/interfaces/StartPlayerTurnPostDrawSubscriber.java
@@ -1,0 +1,5 @@
+package basemod.interfaces;
+
+public interface StartPlayerTurnPostDrawSubscriber extends ISubscriber {
+	void receiveStartPlayerTurnPostDraw(int turn);
+}

--- a/mod/src/main/java/basemod/interfaces/StartPlayerTurnSubscriber.java
+++ b/mod/src/main/java/basemod/interfaces/StartPlayerTurnSubscriber.java
@@ -1,0 +1,5 @@
+package basemod.interfaces;
+
+public interface StartPlayerTurnSubscriber extends ISubscriber {
+	void receiveStartPlayerTurn(int turn);
+}

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/actions/GameActionManager/StartPlayerTurnHook.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/actions/GameActionManager/StartPlayerTurnHook.java
@@ -1,0 +1,33 @@
+package basemod.patches.com.megacrit.cardcrawl.actions.GameActionManager;
+
+import basemod.BaseMod;
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.megacrit.cardcrawl.actions.GameActionManager;
+import com.megacrit.cardcrawl.helpers.ModHelper;
+import javassist.CtBehavior;
+
+@SpirePatch(
+		clz = GameActionManager.class,
+		method = "getNextAction"
+)
+public class StartPlayerTurnHook
+{
+	@SpireInsertPatch(
+			locator = Locator.class
+	)
+	public static void Insert()
+	{
+		// round 2 ~ end battle
+		BaseMod.publishStartPlayerTurn(GameActionManager.turn + 1);
+	}
+
+	private static class Locator extends SpireInsertLocator
+	{
+		@Override
+		public int[] Locate(CtBehavior ctBehavior) throws Exception
+		{
+			Matcher finalMatcher = new Matcher.MethodCallMatcher(ModHelper.class, "isModEnabled");
+			return LineFinder.findInOrder(ctBehavior, finalMatcher);
+		}
+	}
+}

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/actions/GameActionManager/StartPlayerTurnPostDrawHook.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/actions/GameActionManager/StartPlayerTurnPostDrawHook.java
@@ -1,0 +1,33 @@
+package basemod.patches.com.megacrit.cardcrawl.actions.GameActionManager;
+
+import basemod.BaseMod;
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.megacrit.cardcrawl.actions.GameActionManager;
+import com.megacrit.cardcrawl.actions.common.EnableEndTurnButtonAction;
+import javassist.CtBehavior;
+
+@SpirePatch(
+		clz = GameActionManager.class,
+		method = "getNextAction"
+)
+public class StartPlayerTurnPostDrawHook
+{
+	@SpireInsertPatch(
+			locator = Locator.class
+	)
+	public static void Insert()
+	{
+		// round 2 ~ end battle
+		BaseMod.publishStartPlayerTurnPostDraw(GameActionManager.turn);
+	}
+
+	private static class Locator extends SpireInsertLocator
+	{
+		@Override
+		public int[] Locate(CtBehavior ctBehavior) throws Exception
+		{
+			Matcher finalMatcher = new Matcher.NewExprMatcher(EnableEndTurnButtonAction.class);
+			return LineFinder.findInOrder(ctBehavior, finalMatcher);
+		}
+	}
+}

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/rooms/AbstractRoom/StartBattleHook.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/rooms/AbstractRoom/StartBattleHook.java
@@ -18,6 +18,9 @@ public class StartBattleHook {
     )
     public static void Insert(AbstractRoom __instance) {
         BaseMod.publishStartBattle(__instance);
+
+        // Round 1
+        BaseMod.publishStartPlayerTurn(1);
     }
 
     private static class Locator extends SpireInsertLocator {

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/rooms/AbstractRoom/StartPlayerTurnPostDrawHook.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/rooms/AbstractRoom/StartPlayerTurnPostDrawHook.java
@@ -1,0 +1,30 @@
+package basemod.patches.com.megacrit.cardcrawl.rooms.AbstractRoom;
+
+import basemod.BaseMod;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.actions.GameActionManager;
+import com.megacrit.cardcrawl.rooms.AbstractRoom;
+import javassist.CannotCompileException;
+import javassist.expr.ExprEditor;
+import javassist.expr.MethodCall;
+
+@SpirePatch(
+		clz = AbstractRoom.class,
+		method = "update"
+)
+public class StartPlayerTurnPostDrawHook
+{
+	public static ExprEditor Instrument() {
+		return new ExprEditor() {
+			@Override
+			public void edit(MethodCall m) throws CannotCompileException
+			{
+				if (m.getClassName().equals(GameActionManager.class.getCanonicalName())
+						&& m.getMethodName().equals("useNextCombatActions")) {
+					// Round 1
+					m.replace(String.format("{ $_ = $proceed($$); %s.publishStartPlayerTurnPostDraw(1); }", BaseMod.class.getCanonicalName()));
+				}
+			}
+		};
+	}
+}


### PR DESCRIPTION
Although relics, powers, and cards have start turn callbacks, it's still needed for custom mechanisms.