### PR TITLE
Fix crash caused by changing settings in main screen

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/options/SettingsScreen/PopupSwitch.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/options/SettingsScreen/PopupSwitch.java
@@ -12,6 +12,11 @@ import com.megacrit.cardcrawl.screens.options.SettingsScreen;
 public class PopupSwitch {
 	@SpireInsertPatch(rloc=35)
 	public static void Insert(Object __obj_instance, Object typeObj) {
+		// Probably not in a game
+		if (AbstractDungeon.player == null) {
+			return;
+		}
+
 		SettingsScreen screen = (SettingsScreen) __obj_instance;
 		AbstractPlayer.PlayerClass selection = AbstractDungeon.player.chosenClass;
 		if (!BaseMod.isBaseGameCharacter(selection)) {


### PR DESCRIPTION
If you change settings in main screen and click exit button in settings panel, a NullPointerException will be thrown from the patch.
This PR fixed it.