### PR TITLE
Fix value of AbstractCard.tintColor

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/CreateCardImageSwitch.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/CreateCardImageSwitch.java
@@ -54,7 +54,7 @@ public class CreateCardImageSwitch {
 			}
 			
 			//sets the tint and shadow colors
-			ReflectionHacks.setPrivate(__instance, AbstractCard.class, "tintColor", new Color(43.0f, 37.0f, 65.0f, 0.0f));
+			ReflectionHacks.setPrivate(__instance, AbstractCard.class, "tintColor", new Color(43.0f / 255.0f, 37.0f / 255.0f, 65.0f / 255.0f, 0.0f));
 			ReflectionHacks.setPrivate(__instance, AbstractCard.class, "frameShadowColor", 
 					((Color) ReflectionHacks.getPrivateStatic(AbstractCard.class, "FRAME_SHADOW_COLOR")).cpy());
 			


### PR DESCRIPTION
In AbstractCard, the RGB values are integer, which are divided by 255.0 when converted to float.
![image](https://user-images.githubusercontent.com/7110965/154715032-581858bb-f1c1-4cfa-a9e3-a090250623af.png)
