### PR TITLE
Add patch to prevent crashing in Traditional Chinese (ZHT) when the first word of a card description is a keyword

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/PreventCrashDueToKeywordAtStartOfCardTextForTraditionalChinesePatch.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/PreventCrashDueToKeywordAtStartOfCardTextForTraditionalChinesePatch.java
@@ -1,0 +1,36 @@
+package basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard;
+
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.localization.LocalizedStrings;
+import javassist.CtBehavior;
+
+import java.util.ArrayList;
+
+// This fixes an issue that is present in the base game. In the separate logic for Chinese-language text parsing,
+// if the first word of a card description is a keyword, the first line of card text ends up being the empty string.
+// In Traditional Chinese, LocalizedString.PERIOD is also the empty string, which causes the logic that tries to fix
+// cases like this to crash due to try to access array index -1. (I suspect the logic is intended for fixing periods at
+// the end of the description that would otherwise spill over to their own line, which explains why it doesn't account
+// for finding lines like this at the start of the string).
+// Simplified Chinese does not have this issue because LocalizedString.PERIOD is 。(in theory, if a card description
+// started with a 。, the same problem would happen).
+// To fix this, we insert our own code to remove lines at the start of the description that equal the localized period
+// string. That removes the meaningless lines and lets the rest of the logic run without crashing for all Chinese text.
+@SpirePatch(clz = AbstractCard.class, method = "initializeDescriptionCN")
+public class PreventCrashDueToKeywordAtStartOfCardTextForTraditionalChinesePatch {
+    @SpireInsertPatch(locator = Locator.class)
+    public static void preventCrash(AbstractCard __instance) {
+        while (__instance.description.size() > 0 && __instance.description.get(0).text.equals(LocalizedStrings.PERIOD)) {
+            __instance.description.remove(0);
+        }
+    }
+
+    private static class Locator extends SpireInsertLocator {
+        @Override
+        public int[] Locate(CtBehavior ctBehavior) throws Exception {
+            Matcher finalMatcher = new Matcher.MethodCallMatcher(ArrayList.class, "size");
+            return LineFinder.findInOrder(ctBehavior, finalMatcher);
+        }
+    }
+}


### PR DESCRIPTION
This fixes a crash that Vex and MichaelMayhem noticed as part of Downfall's release (discussion at https://discord.com/channels/309399445785673728/398373038732738570/957327417792413706). After looking at it enough to understand what was going on it wasn't much more work to make a patch, so I did.

Essentially, initializeDescriptionCN has logic to clean up descriptions by moving lines that would only have a period character to combine them with the previous line. But:
* That logic breaks if there's a localized period as the first line of the description
* In Traditional Chinese (ZHT), the localized period is the empty string
* If a card descriptions starts with a modded keyword, the first line of the description is the empty string (this might only happen for cards that don't have a ZHT translation, but that's most modded cards, since ZHS is what Chinese translations normally focus on)

Combining those is how we get this error. I reproduced this by loading the current version of Downfall (v4.0.5) in Traditional Chinese (ZHT). Vex was making a patch to temporarily prevent ZHT in Downfall to avoid this, so I don't think it's too urgent to get this out -- whenever you have the time to make a BaseMod update.

Card formatting for untranslated cards is really ugly, but that's an existing problem and at least this fixes the crash.