### PR TITLE
No log spam viewing curse cards with cost

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/BackgroundFix.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/BackgroundFix.java
@@ -127,7 +127,7 @@ public class BackgroundFix
 		@SuppressWarnings("unused")
 		public static TextureAtlas.AtlasRegion getEnergyOrb(AbstractCard card, TextureAtlas.AtlasRegion orb)
 		{
-			if (card.color == AbstractCard.CardColor.COLORLESS) {
+			if (card.color == AbstractCard.CardColor.COLORLESS || card.color == AbstractCard.CardColor.CURSE) {
 				return orb;
 			}
 


### PR DESCRIPTION
Both colorless and curse cards go through this patch, and the current code results in attempting to load a null texture every frame which spams the log