### PR TITLE
Fix CN text when magic value is at start of a line

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/FixDescriptionWidthCustomDynamicVariableCN.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/FixDescriptionWidthCustomDynamicVariableCN.java
@@ -18,19 +18,19 @@ public class FixDescriptionWidthCustomDynamicVariableCN
 			localvars={"word", "currentWidth", "sbuilder", "numLines", "CN_DESC_BOX_WIDTH"}
 	)
 	public static void Insert(AbstractCard __instance, @ByRef String[] word, @ByRef float[] currentWidth,
-							  @ByRef StringBuilder[] currentLine, @ByRef int[] numLines,
+							  StringBuilder currentLine, @ByRef int[] numLines,
 							  float CN_DESC_BOX_WIDTH)
 	{
 		if (word[0].startsWith("!")) {
 			GlyphLayout gl = new GlyphLayout(FontHelper.cardDescFont_N, "!M!");
 			if (currentWidth[0] + gl.width > CN_DESC_BOX_WIDTH) {
 				++numLines[0];
-				__instance.description.add(new DescriptionLine(currentLine[0].toString(), currentWidth[0]));
-				currentLine[0] = new StringBuilder();
+				__instance.description.add(new DescriptionLine(currentLine.toString(), currentWidth[0]));
+				currentLine.setLength(0);
 				currentWidth[0] = gl.width;
-				currentLine[0].append(" ").append(word[0]).append("! ");
+				currentLine.append(" ").append(word[0]).append("! ");
 			} else {
-				currentLine[0].append(" ").append(word[0]).append("! ");
+				currentLine.append(" ").append(word[0]).append("! ");
 				currentWidth[0] += gl.width;
 			}
 			word[0] = "";


### PR DESCRIPTION
I created this PR on behalf of @ak-dream. Please add them as change contributor.

Please see screenshot below, the first character of the third line should be a magic number, but it copied description from the second line. The reason is that the string build wasn't cleared properly. With the fix, this can be rendered correctly.

Without the fix:
![image](https://user-images.githubusercontent.com/7110965/166133389-c8407d33-94fb-45fc-bb92-1edf8e6e474c.png)

With the fix:
![image](https://user-images.githubusercontent.com/7110965/166133408-ead5b6e4-63c1-41b3-be5b-2fe73036badd.png)
