### PR TITLE
separate cn description patch, shrink cn scv description

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/ShrinkLongDescription.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/ShrinkLongDescription.java
@@ -14,6 +14,10 @@ public class ShrinkLongDescription
 			clz=SingleCardViewPopup.class,
 			method="renderDescription"
 	)
+	@SpirePatch(
+			clz=SingleCardViewPopup.class,
+			method="renderDescriptionCN"
+	)
 	public static class ShiftSizeLineDescription
 	{
 		@SpireInsertPatch(


### PR DESCRIPTION
patch did not work correctly for scv renderDescriptionCN

Also not sure why font shrinking was not applied on cn scv, but adding an annotation is easier than trying to make specifically basemod description shrinking not apply to cn scv energy rendering