### PR TITLE
Remove -1 case requirement from dynamic text

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/DynamicTextBlocks.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/DynamicTextBlocks.java
@@ -77,7 +77,7 @@ public class DynamicTextBlocks {
     @SpirePatch2(clz = AbstractCard.class, method = "renderDescriptionCN")
     public static class UpdateOnRender {
         @SpirePrefixPatch
-        public static void onPreview(AbstractCard __instance) {
+        public static void onRender(AbstractCard __instance) {
             if (DynamicTextField.isDynamic.get(__instance)) {
                 String varData = parseVarData(__instance);
                 if (!DynamicTextField.varData.get(__instance).equals(varData)) {
@@ -93,7 +93,7 @@ public class DynamicTextBlocks {
     @SpirePatch2(clz = SingleCardViewPopup.class, method = "renderDescriptionCN")
     public static class UpdateOnRenderSCV {
         @SpirePrefixPatch
-        public static void onPreview(SingleCardViewPopup __instance, AbstractCard ___card) {
+        public static void onRender(SingleCardViewPopup __instance, AbstractCard ___card) {
             if (DynamicTextField.isDynamic.get(___card)) {
                 String varData = parseVarData(___card);
                 if (!DynamicTextField.varData.get(___card).equals(varData)) {

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/DynamicTextBlocks.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/DynamicTextBlocks.java
@@ -5,10 +5,10 @@ import com.evacipated.cardcrawl.modthespire.lib.*;
 import com.megacrit.cardcrawl.actions.GameActionManager;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.CardGroup;
-import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.screens.ExhaustPileViewScreen;
+import com.megacrit.cardcrawl.screens.SingleCardViewPopup;
 import javassist.CannotCompileException;
 import javassist.CtBehavior;
 import javassist.expr.ExprEditor;
@@ -33,6 +33,7 @@ public class DynamicTextBlocks {
     @SpirePatch(clz= AbstractCard.class, method=SpirePatch.CLASS)
     public static class DynamicTextField {
         public static final SpireField<Boolean> isDynamic = new SpireField<>(() -> Boolean.FALSE);
+        public static final SpireField<String> varData = new SpireField<>(() -> "");
     }
 
     //When we render said card copy, set its field and initialize description
@@ -42,7 +43,6 @@ public class DynamicTextBlocks {
         public static void setField(ExhaustPileViewScreen __instance, AbstractCard toAdd) {
             if (DynamicTextField.isDynamic.get(toAdd)) {
                 ExhaustViewFixField.exhaustViewCopy.set(toAdd, true);
-                toAdd.initializeDescription();
             }
         }
 
@@ -51,64 +51,6 @@ public class DynamicTextBlocks {
             public int[] Locate(CtBehavior ctMethodToPatch) throws Exception {
                 Matcher finalMatcher = new Matcher.MethodCallMatcher(CardGroup.class, "addToBottom");
                 return LineFinder.findInOrder(ctMethodToPatch, finalMatcher);
-            }
-        }
-    }
-
-    //Allows dynamic text to work with powers while in your hand and when targeting enemies
-    @SpirePatch(clz = AbstractCard.class, method = "applyPowers")
-    @SpirePatch(clz = AbstractCard.class, method = "calculateCardDamage")
-    public static class UpdateTextForPowers {
-        @SpirePostfixPatch
-        public static void updateAfterVarChange(AbstractCard __instance) {
-            if (DynamicTextField.isDynamic.get(__instance)) {
-                __instance.initializeDescription();
-            }
-        }
-    }
-
-    //Allows !L! to set its location properly by forcing an update when the deck is initialized at the start of combat
-    @SpirePatch(clz = CardGroup.class, method = "initializeDeck")
-    public static class UpdateTextOnDeckCreation {
-        @SpirePostfixPatch()
-        public static void updateAfterAdding(CardGroup __instance, CardGroup masterDeck) {
-            for (AbstractCard c : __instance.group) {
-                if (DynamicTextField.isDynamic.get(c)) {
-                    c.initializeDescription();
-                }
-            }
-        }
-    }
-
-    //Force a Location update when a card is exhausted.
-    @SpirePatch(clz = CardGroup.class, method = "moveToExhaustPile")
-    public static class UpdateTextOnExhaust{
-        @SpirePostfixPatch()
-        public static void updateAfter(CardGroup __instance, AbstractCard c) {
-            if (DynamicTextField.isDynamic.get(c)) {
-                c.initializeDescription();
-            }
-        }
-    }
-
-    //Force an update when a card is upgraded in master deck. We dont have an onUpgrade hook but basegame permanent upgrades call this method after upgrading.
-    @SpirePatch2(clz = AbstractPlayer.class, method = "bottledCardUpgradeCheck")
-    public static class UpdateOnMasterDeckUpgrade {
-        @SpirePostfixPatch
-        public static void onUpgrade(AbstractCard c) {
-            if (DynamicTextField.isDynamic.get(c)) {
-                c.initializeDescription();
-            }
-        }
-    }
-
-    //Force an update in the smithing preview
-    @SpirePatch2(clz = AbstractCard.class, method = "displayUpgrades")
-    public static class UpdateOnUpgradePreview {
-        @SpirePostfixPatch
-        public static void onPreview(AbstractCard __instance) {
-            if (DynamicTextField.isDynamic.get(__instance)) {
-                __instance.initializeDescription();
             }
         }
     }
@@ -128,6 +70,49 @@ public class DynamicTextBlocks {
                 }
             };
         }
+    }
+
+    //Force an update at render time if the values have changed since we last checked
+    @SpirePatch2(clz = AbstractCard.class, method = "renderDescription")
+    @SpirePatch2(clz = AbstractCard.class, method = "renderDescriptionCN")
+    public static class UpdateOnRender {
+        @SpirePrefixPatch
+        public static void onPreview(AbstractCard __instance) {
+            if (DynamicTextField.isDynamic.get(__instance)) {
+                String varData = parseVarData(__instance);
+                if (!DynamicTextField.varData.get(__instance).equals(varData)) {
+                    DynamicTextField.varData.set(__instance, varData);
+                    __instance.initializeDescription();
+                }
+            }
+        }
+    }
+
+    //Force an update at render time if the values have changed since we last checked, SCV style
+    @SpirePatch2(clz = SingleCardViewPopup.class, method = "renderDescription")
+    @SpirePatch2(clz = SingleCardViewPopup.class, method = "renderDescriptionCN")
+    public static class UpdateOnRenderSCV {
+        @SpirePrefixPatch
+        public static void onPreview(SingleCardViewPopup __instance, AbstractCard ___card) {
+            if (DynamicTextField.isDynamic.get(___card)) {
+                String varData = parseVarData(___card);
+                if (!DynamicTextField.varData.get(___card).equals(varData)) {
+                    DynamicTextField.varData.set(___card, varData);
+                    ___card.initializeDescription();
+                }
+            }
+        }
+    }
+
+    public static String parseVarData(AbstractCard c) {
+        StringBuilder sb = new StringBuilder();
+        java.util.regex.Matcher m = PATTERN.matcher(c.rawDescription.replace(DYNAMIC_KEY,""));
+        while (m.find()) {
+            String key = m.group().substring(1, m.group().length()-1).split("\\|")[0];
+            Integer var = getVarFromDynvarKey(c, key);
+            sb.append(key).append(var != null ? var : "?");
+        }
+        return sb.toString();
     }
 
     public static String[] checkForUnwrapping(AbstractCard c, String[] splitText) {
@@ -150,20 +135,16 @@ public class DynamicTextBlocks {
         }
     }
 
-    public static String unwrap(AbstractCard c, String key) {
-        //Cut the leading { and the trailing } and then split the string along each |
-        key = key.substring(1, key.length()-1);
-        String[] parts = key.split("\\|");
-        //Our first piece will always be the dynamic variable we care about. Find its value
+    public static Integer getVarFromDynvarKey(AbstractCard c, String dynvarKey) {
         Integer var = null;
-        if (parts[0].equals("!D!")) {
+        if (dynvarKey.equals("!D!")) {
             //Uses !D! for damage, just like normal dynvars, same applies to !B! and !M!
             var = c.damage;
-        } else if (parts[0].equals("!B!")) {
+        } else if (dynvarKey.equals("!B!")) {
             var = c.block;
-        } else if (parts[0].equals("!M!")) {
+        } else if (dynvarKey.equals("!M!")) {
             var = c.magicNumber;
-        } else if (parts[0].equals("!Location!")) {
+        } else if (dynvarKey.equals("!Location!")) {
             //Used to grab the location of the card. Isn't a real dynvar, but we can pretend
             var = -1; //Master Deck, Compendium, Limbo, modded CardGroups
             if (CardCrawlGame.dungeon != null && AbstractDungeon.player != null) {
@@ -178,19 +159,28 @@ public class DynamicTextBlocks {
                     var = 3;
                 }
             }
-        } else if (parts[0].equals("!Upgrades!")) {
+        } else if (dynvarKey.equals("!Upgrades!")) {
             //Used to grab the amount of times the card was upgraded. Isn't a real dynvar
             var = c.timesUpgraded;
-        } else if (parts[0].equals("!Turn!")) {
+        } else if (dynvarKey.equals("!Turn!")) {
             //Used to grab the turn amount. Isn't a real dynvar
             var = -1;
             if (AbstractDungeon.player != null) {
                 var = GameActionManager.turn;
             }
-        } else if (BaseMod.cardDynamicVariableMap.containsKey(parts[0].replace("!",""))) {
+        } else if (BaseMod.cardDynamicVariableMap.containsKey(dynvarKey.replace("!",""))) {
             //Check to see if it's a recognized dynvar registered by some mod
-            var = BaseMod.cardDynamicVariableMap.get(parts[0].replace("!","")).value(c);
+            var = BaseMod.cardDynamicVariableMap.get(dynvarKey.replace("!","")).value(c);
         }
+        return var;
+    }
+
+    public static String unwrap(AbstractCard c, String key) {
+        //Cut the leading { and the trailing } and then split the string along each |
+        key = key.substring(1, key.length()-1);
+        String[] parts = key.split("\\|");
+        //Our first piece will always be the dynamic variable we care about. Find its value
+        Integer var = getVarFromDynvarKey(c, parts[0]);
         //Clean up the first string since we don't need it
         parts = Arrays.copyOfRange(parts, 1, parts.length);
         //If we found a var then we can do stuff, else just return an empty string

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/runHistory/TinyCard/HitboxPatch.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/runHistory/TinyCard/HitboxPatch.java
@@ -1,0 +1,17 @@
+package basemod.patches.com.megacrit.cardcrawl.screens.runHistory.TinyCard;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch2;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.screens.runHistory.TinyCard;
+
+public class HitboxPatch {
+    @SpirePatch2(clz = TinyCard.class, method = SpirePatch.CONSTRUCTOR)
+    public static class FixHitboxHeight {
+        @SpirePostfixPatch
+        public static void scaleProperly(TinyCard __instance) {
+            __instance.hb.height *= Settings.scale;
+        }
+    }
+}


### PR DESCRIPTION
Fixes dynamic text blocks to reinitialize the description if any dynamic variables checked via dynamic text have been updated. Fixes multiple issues where a manual initializeDescription call was needed, and removes the need for a -1 case for uninitialized values in the compendium.