### PR TITLE
In CardModifier, add a space before period when using CN language

### DIFF
--- a/mod/src/main/java/basemod/cardmods/EtherealMod.java
+++ b/mod/src/main/java/basemod/cardmods/EtherealMod.java
@@ -2,6 +2,7 @@ package basemod.cardmods;
 
 import basemod.abstracts.AbstractCardModifier;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.helpers.GameDictionary;
 import com.megacrit.cardcrawl.localization.LocalizedStrings;
 import org.apache.commons.lang3.StringUtils;
@@ -11,7 +12,7 @@ public class EtherealMod extends AbstractCardModifier {
 
     @Override
     public String modifyDescription(String rawDescription, AbstractCard card) {
-        return StringUtils.capitalize(GameDictionary.ETHEREAL.NAMES[0]) + LocalizedStrings.PERIOD + " NL " + rawDescription;
+        return StringUtils.capitalize(GameDictionary.ETHEREAL.NAMES[0]) + (Settings.lineBreakViaCharacter ? " " : "") + LocalizedStrings.PERIOD + " NL " + rawDescription;
     }
 
     @Override

--- a/mod/src/main/java/basemod/cardmods/ExhaustMod.java
+++ b/mod/src/main/java/basemod/cardmods/ExhaustMod.java
@@ -2,6 +2,7 @@ package basemod.cardmods;
 
 import basemod.abstracts.AbstractCardModifier;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.helpers.GameDictionary;
 import com.megacrit.cardcrawl.localization.LocalizedStrings;
 import org.apache.commons.lang3.StringUtils;
@@ -11,7 +12,7 @@ public class ExhaustMod extends AbstractCardModifier {
 
     @Override
     public String modifyDescription(String rawDescription, AbstractCard card) {
-        return rawDescription + " NL " + StringUtils.capitalize(GameDictionary.EXHAUST.NAMES[0]) + LocalizedStrings.PERIOD;
+        return rawDescription + " NL " + StringUtils.capitalize(GameDictionary.EXHAUST.NAMES[0]) + (Settings.lineBreakViaCharacter ? " " : "") + LocalizedStrings.PERIOD;
     }
 
     @Override

--- a/mod/src/main/java/basemod/cardmods/InnateMod.java
+++ b/mod/src/main/java/basemod/cardmods/InnateMod.java
@@ -2,6 +2,7 @@ package basemod.cardmods;
 
 import basemod.abstracts.AbstractCardModifier;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.helpers.GameDictionary;
 import com.megacrit.cardcrawl.localization.LocalizedStrings;
 import org.apache.commons.lang3.StringUtils;
@@ -11,7 +12,7 @@ public class InnateMod extends AbstractCardModifier {
 
     @Override
     public String modifyDescription(String rawDescription, AbstractCard card) {
-        return StringUtils.capitalize(GameDictionary.INNATE.NAMES[0]) + LocalizedStrings.PERIOD + " NL " + rawDescription;
+        return StringUtils.capitalize(GameDictionary.INNATE.NAMES[0]) + (Settings.lineBreakViaCharacter ? " " : "") + LocalizedStrings.PERIOD + " NL " + rawDescription;
     }
 
     @Override

--- a/mod/src/main/java/basemod/cardmods/RetainMod.java
+++ b/mod/src/main/java/basemod/cardmods/RetainMod.java
@@ -2,6 +2,7 @@ package basemod.cardmods;
 
 import basemod.abstracts.AbstractCardModifier;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.helpers.GameDictionary;
 import com.megacrit.cardcrawl.localization.LocalizedStrings;
 import org.apache.commons.lang3.StringUtils;
@@ -11,7 +12,7 @@ public class RetainMod extends AbstractCardModifier {
 
     @Override
     public String modifyDescription(String rawDescription, AbstractCard card) {
-        return StringUtils.capitalize(GameDictionary.RETAIN.NAMES[0]) + LocalizedStrings.PERIOD + " NL " + rawDescription;
+        return StringUtils.capitalize(GameDictionary.RETAIN.NAMES[0]) + (Settings.lineBreakViaCharacter ? " " : "") + LocalizedStrings.PERIOD + " NL " + rawDescription;
     }
 
     @Override


### PR DESCRIPTION
When using CN language, period is not considered as part of keyword. An additional space is needed to make the keyword correctly parsed.