### PR TITLE
Add an option for custom events who end with a reward screen

### DIFF
--- a/mod/src/main/java/basemod/BaseMod.java
+++ b/mod/src/main/java/basemod/BaseMod.java
@@ -1312,7 +1312,8 @@ public class BaseMod {
 				params.spawnCondition,
 				params.overrideEventID,
 				params.bonusCondition,
-				params.eventType
+				params.eventType,
+				params
 		);
 	}
 

--- a/mod/src/main/java/basemod/eventUtil/AddEventParams.java
+++ b/mod/src/main/java/basemod/eventUtil/AddEventParams.java
@@ -23,6 +23,8 @@ public class AddEventParams
 
 	public String overrideEventID = null;
 
+	public boolean endsWithRewardsUI = false;
+
 	public static class Builder
 	{
 		private AddEventParams params = new AddEventParams();
@@ -77,6 +79,11 @@ public class AddEventParams
 		public Builder eventType(EventUtils.EventType eventType)
 		{
 			params.eventType = eventType;
+			return this;
+		}
+
+		public Builder endsWithRewardsUI(boolean value) {
+			params.endsWithRewardsUI = value;
 			return this;
 		}
 	}

--- a/mod/src/main/java/basemod/eventUtil/EventUtils.java
+++ b/mod/src/main/java/basemod/eventUtil/EventUtils.java
@@ -2,7 +2,6 @@ package basemod.eventUtil;
 
 import basemod.eventUtil.util.Condition;
 import basemod.eventUtil.util.ConditionalEvent;
-import com.evacipated.cardcrawl.modthespire.lib.SpireReturn;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.events.AbstractEvent;
 import com.megacrit.cardcrawl.localization.EventStrings;
@@ -15,7 +14,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.function.Predicate;
 
 public class EventUtils {
     /* D O C U M E N T A T I O N
@@ -68,10 +66,25 @@ public class EventUtils {
     private static int id = 0;
 
     public static <T extends AbstractEvent> void registerEvent(String ID, Class<T> eventClass, AbstractPlayer.PlayerClass playerClass, String[] actIDs, Condition spawnCondition, String overrideEvent, Condition bonusCondition, EventType type) {
+        registerEvent(ID, eventClass, playerClass, actIDs, spawnCondition, overrideEvent, bonusCondition, type, null);
+    }
+
+    public static <T extends AbstractEvent> void registerEvent(String ID, Class<T> eventClass, AbstractPlayer.PlayerClass playerClass, String[] actIDs, Condition spawnCondition, String overrideEvent, Condition bonusCondition, EventType type, AddEventParams additionalParams) {
         /*if (!(overrideEvent != null || spawnCondition != null || actIDs != null || playerClass != null || bonusCondition != null)) {
             eventLogger.info("Event " + eventClass.getName() + " has no special conditions, and should be registered through BaseMod instead.");
             return;
         }*/
+
+        if (additionalParams == null) {
+            additionalParams = new AddEventParams.Builder(ID, eventClass)
+                    .eventType(type)
+                    .playerClass(playerClass)
+                    .dungeonIDs(actIDs)
+                    .spawnCondition(spawnCondition)
+                    .bonusCondition(bonusCondition)
+                    .overrideEvent(overrideEvent)
+                    .create();
+        }
 
         ID = ID.replace(' ', '_');
 
@@ -83,7 +96,8 @@ public class EventUtils {
         ConditionalEvent<T> c = new ConditionalEvent<T>(eventClass,
                 playerClass,
                 spawnCondition,
-                actIDs == null ? new String[]{} : actIDs);
+                actIDs == null ? new String[]{} : actIDs,
+                additionalParams);
 
         if (type == EventType.FULL_REPLACE && overrideEvent != null) {
             c.overrideEvent = ID;

--- a/mod/src/main/java/basemod/eventUtil/util/ConditionalEvent.java
+++ b/mod/src/main/java/basemod/eventUtil/util/ConditionalEvent.java
@@ -1,5 +1,7 @@
 package basemod.eventUtil.util;
 
+import basemod.eventUtil.AddEventParams;
+import basemod.patches.com.megacrit.cardcrawl.events.AbstractEvent.AdditionalEventParameters;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.events.AbstractEvent;
@@ -18,10 +20,13 @@ public class ConditionalEvent<T extends AbstractEvent> {
 
     public String overrideEvent = "";
 
-    public ConditionalEvent(Class<T> eventClass, AbstractPlayer.PlayerClass playerClass, Condition spawnCondition, String[] actIDs) {
+    private final AddEventParams additionalParams;
+
+    public ConditionalEvent(Class<T> eventClass, AbstractPlayer.PlayerClass playerClass, Condition spawnCondition, String[] actIDs, AddEventParams additionalParams) {
         this.eventClass = eventClass;
         this.playerClass = playerClass;
         this.spawnCondition = spawnCondition;
+        this.additionalParams = additionalParams;
 
         if (spawnCondition == null)
             this.spawnCondition = () -> true;
@@ -31,7 +36,9 @@ public class ConditionalEvent<T extends AbstractEvent> {
 
     public AbstractEvent getEvent() {
         try {
-            return eventClass.getConstructor().newInstance();
+            AbstractEvent event = eventClass.getConstructor().newInstance();
+            AdditionalEventParameters.additionalParameters.set(event, additionalParams);
+            return event;
         } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
             eventLogger.info("Failed to instantiate event " + eventClass.getName());
             e.printStackTrace();

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/events/AbstractEvent/AdditionalEventParameters.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/events/AbstractEvent/AdditionalEventParameters.java
@@ -1,0 +1,12 @@
+package basemod.patches.com.megacrit.cardcrawl.events.AbstractEvent;
+
+import basemod.eventUtil.AddEventParams;
+import com.evacipated.cardcrawl.modthespire.lib.SpireField;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.events.AbstractEvent;
+
+@SpirePatch(clz = AbstractEvent.class, method = SpirePatch.CLASS)
+public class AdditionalEventParameters
+{
+    public static SpireField<AddEventParams> additionalParameters = new SpireField<>(() -> null);
+}

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/ui/buttons/ProceedButton/EventCombatProceed.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/ui/buttons/ProceedButton/EventCombatProceed.java
@@ -2,10 +2,18 @@ package basemod.patches.com.megacrit.cardcrawl.ui.buttons.ProceedButton;
 
 import basemod.abstracts.events.PhasedEvent;
 import basemod.abstracts.events.phases.CombatPhase;
+import basemod.eventUtil.AddEventParams;
+import basemod.patches.com.megacrit.cardcrawl.events.AbstractEvent.AdditionalEventParameters;
 import com.evacipated.cardcrawl.modthespire.lib.*;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.events.AbstractEvent;
+import com.megacrit.cardcrawl.events.exordium.Mushrooms;
 import com.megacrit.cardcrawl.ui.buttons.ProceedButton;
+import javassist.CannotCompileException;
 import javassist.CtBehavior;
+import javassist.NotFoundException;
+import javassist.expr.ExprEditor;
+import javassist.expr.Instanceof;
 
 @SpirePatch(
         clz = ProceedButton.class,
@@ -38,5 +46,29 @@ public class EventCombatProceed {
             Matcher finalMatcher = new Matcher.MethodCallMatcher(ProceedButton.class, "hide");
             return LineFinder.findInOrder(ctMethodToPatch, finalMatcher);
         }
+    }
+
+    @SpireInstrumentPatch
+    public static ExprEditor Instrument() {
+        return new ExprEditor() {
+            @Override
+            public void edit(Instanceof i) throws CannotCompileException {
+                try {
+                    if (i.getType().getName().equals(Mushrooms.class.getName())) {
+                        i.replace(String.format(" $_ = $proceed($$) || %s.check($1); ", EventCombatProceed.class.getName()));
+                    }
+                } catch (NotFoundException ignored) {}
+            }
+        };
+    }
+
+    @SuppressWarnings("unused")
+    public static boolean check(Object event) {
+        if (event instanceof AbstractEvent) {
+            AddEventParams additionalParams = AdditionalEventParameters.additionalParameters.get(event);
+            return additionalParams != null && additionalParams.endsWithRewardsUI;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
All combat events and Lab event (which gives you potions) has special logic for proceed button. The rewards dialog won't hide when clicking proceed button incase players want to go back to event page to acquire them.

This commit add an option for this. Modders who making such custom events don't need to patch it any more.