### PR TITLE
Add screen-space rendering postprocessor

### DIFF
--- a/mod/src/main/java/basemod/helpers/ScreenPostProcessorManager.java
+++ b/mod/src/main/java/basemod/helpers/ScreenPostProcessorManager.java
@@ -3,9 +3,12 @@ package basemod.helpers;
 import basemod.interfaces.ScreenPostProcessor;
 import basemod.patches.com.megacrit.cardcrawl.core.CardCrawlGame.ApplyScreenPostProcessor;
 
+import java.util.Comparator;
+
 public class ScreenPostProcessorManager {
     public static void addPostProcessor(ScreenPostProcessor postProcessor) {
         ApplyScreenPostProcessor.postProcessors.add(postProcessor);
+        ApplyScreenPostProcessor.postProcessors.sort(Comparator.comparingInt(ScreenPostProcessor::priority));
     }
 
     public static boolean removePostProcessor(ScreenPostProcessor postProcessor) {

--- a/mod/src/main/java/basemod/helpers/ScreenPostProcessorManager.java
+++ b/mod/src/main/java/basemod/helpers/ScreenPostProcessorManager.java
@@ -1,0 +1,14 @@
+package basemod.helpers;
+
+import basemod.interfaces.ScreenPostProcessor;
+import basemod.patches.com.megacrit.cardcrawl.core.CardCrawlGame.ApplyScreenPostProcessor;
+
+public class ScreenPostProcessorManager {
+    public static void addPostProcessor(ScreenPostProcessor postProcessor) {
+        ApplyScreenPostProcessor.postProcessors.add(postProcessor);
+    }
+
+    public static boolean removePostProcessor(ScreenPostProcessor postProcessor) {
+        return ApplyScreenPostProcessor.postProcessors.remove(postProcessor);
+    }
+}

--- a/mod/src/main/java/basemod/interfaces/ScreenPostProcessor.java
+++ b/mod/src/main/java/basemod/interfaces/ScreenPostProcessor.java
@@ -1,0 +1,9 @@
+package basemod.interfaces;
+
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+
+public interface ScreenPostProcessor {
+    void postProcess(SpriteBatch sb, TextureRegion frameTexture, OrthographicCamera camera);
+}

--- a/mod/src/main/java/basemod/interfaces/ScreenPostProcessor.java
+++ b/mod/src/main/java/basemod/interfaces/ScreenPostProcessor.java
@@ -6,4 +6,9 @@ import com.badlogic.gdx.graphics.g2d.TextureRegion;
 
 public interface ScreenPostProcessor {
     void postProcess(SpriteBatch sb, TextureRegion frameTexture, OrthographicCamera camera);
+
+    // Lower = earlier
+    default int priority() {
+        return 50;
+    }
 }

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/core/CardCrawlGame/ApplyScreenPostProcessor.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/core/CardCrawlGame/ApplyScreenPostProcessor.java
@@ -44,6 +44,7 @@ public class ApplyScreenPostProcessor {
 
         setDefaultFrameBuffer(primaryFrameBuffer);
         primaryFrameBuffer.begin();
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
     }
 
     public static class BeginLocator extends SpireInsertLocator {
@@ -69,6 +70,7 @@ public class ApplyScreenPostProcessor {
 
             setDefaultFrameBuffer(primaryFrameBuffer);
             primaryFrameBuffer.begin();
+            Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
             sb.begin();
 
             postProcessor.postProcess(sb, secondaryFboRegion, camera);

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/core/CardCrawlGame/ApplyScreenPostProcessor.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/core/CardCrawlGame/ApplyScreenPostProcessor.java
@@ -1,0 +1,97 @@
+package basemod.patches.com.megacrit.cardcrawl.core.CardCrawlGame;
+
+import basemod.interfaces.ScreenPostProcessor;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.graphics.glutils.FrameBuffer;
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.core.Settings;
+import javassist.CtBehavior;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@SpirePatch(clz = CardCrawlGame.class, method = "render")
+public class ApplyScreenPostProcessor {
+    public static final List<ScreenPostProcessor> postProcessors = new ArrayList<>();
+
+    private static FrameBuffer primaryFrameBuffer;
+    private static FrameBuffer secondaryFrameBuffer;
+    private static TextureRegion primaryFboRegion;
+    private static TextureRegion secondaryFboRegion;
+    private static boolean usingFrameBuffer = false;
+
+    @SpireInsertPatch(locator = BeginLocator.class)
+    public static void BeforeSpriteBatchBegin(CardCrawlGame __instance) {
+        if (!postProcessors.isEmpty()) {
+            if (primaryFrameBuffer == null) {
+                initFrameBuffer();
+            }
+
+            usingFrameBuffer = true;
+            primaryFrameBuffer.begin();
+        }
+    }
+
+    public static class BeginLocator extends SpireInsertLocator {
+        @Override
+        public int[] Locate(CtBehavior ctBehavior) throws Exception {
+            Matcher.MethodCallMatcher matcher = new Matcher.MethodCallMatcher(SpriteBatch.class, "begin");
+            return LineFinder.findInOrder(ctBehavior, matcher);
+        }
+    }
+
+    public static void BeforeSpriteBatchEnd(SpriteBatch sb, OrthographicCamera camera) {
+        if (!usingFrameBuffer) {
+            return;
+        }
+
+        sb.end();
+        primaryFrameBuffer.end();
+
+        for (ScreenPostProcessor postProcessor : postProcessors) {
+            FrameBuffer tempBuffer = primaryFrameBuffer;
+            primaryFrameBuffer = secondaryFrameBuffer;
+            secondaryFrameBuffer = tempBuffer;
+
+            TextureRegion tempRegion = primaryFboRegion;
+            primaryFboRegion = secondaryFboRegion;
+            secondaryFboRegion = tempRegion;
+
+            primaryFrameBuffer.begin();
+            sb.begin();
+
+            postProcessor.postProcess(sb, secondaryFboRegion, camera);
+
+            sb.end();
+            primaryFrameBuffer.end();
+        }
+
+        sb.setShader(null);
+        sb.begin();
+        sb.setColor(Color.WHITE);
+
+        sb.setProjectionMatrix(camera.combined);
+        sb.draw(primaryFboRegion, 0, 0, Settings.WIDTH, Settings.HEIGHT);
+
+        usingFrameBuffer = false;
+    }
+
+    private static void initFrameBuffer() {
+        int width = Gdx.graphics.getWidth();
+        int height = Gdx.graphics.getHeight();
+
+        primaryFrameBuffer = new FrameBuffer(Pixmap.Format.RGB888, width, height, false);
+        primaryFboRegion = new TextureRegion(primaryFrameBuffer.getColorBufferTexture());
+        primaryFboRegion.flip(false, true);
+
+        secondaryFrameBuffer = new FrameBuffer(Pixmap.Format.RGB888, width, height, false);
+        secondaryFboRegion = new TextureRegion(secondaryFrameBuffer.getColorBufferTexture());
+        secondaryFboRegion.flip(false, true);
+    }
+}

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/core/CardCrawlGame/ApplyScreenPostProcessor.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/core/CardCrawlGame/ApplyScreenPostProcessor.java
@@ -106,4 +106,21 @@ public class ApplyScreenPostProcessor {
     private static void setDefaultFrameBuffer(FrameBuffer fbo) {
         ReflectionHacks.setPrivateStatic(GLFrameBuffer.class, "defaultFramebufferHandle", fbo.getFramebufferHandle());
     }
+
+    @SpirePatch2(
+            clz = SpriteBatch.class,
+            method = "setupMatrices"
+    )
+    @SpirePatch2(
+            clz = PolygonSpriteBatch.class,
+            method = "setupMatrices"
+    )
+    private static class ShaderScreenSizeUniform {
+        private static void Postfix(ShaderProgram ___customShader) {
+            if (___customShader != null) {
+                ___customShader.setUniformf("u_scale", Settings.scale);
+                ___customShader.setUniformf("u_screenSize", Settings.WIDTH, Settings.HEIGHT);
+            }
+        }
+    }
 }

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/core/CardCrawlGame/RenderHooks.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/core/CardCrawlGame/RenderHooks.java
@@ -64,10 +64,11 @@ public class RenderHooks {
 	    
 		@SpireInsertPatch(
 				locator=Locator.class,
-				localvars={"sb"}
+				localvars={"sb", "camera"}
 		)
-	    public static void Insert(Object __obj_instance, SpriteBatch sb) {
+	    public static void Insert(Object __obj_instance, SpriteBatch sb, OrthographicCamera camera) {
 	        BaseMod.publishPostRender(sb);
+			ApplyScreenPostProcessor.BeforeSpriteBatchEnd(sb, camera);
 	    }
 
 	    private static class Locator extends SpireInsertLocator


### PR DESCRIPTION
Modders can use this to make effects after whole screen has been rendered. The main reason for adding this is that if multiple mods use these patches, they are not compatible. Some effect may be overwrite by others.
Here's a sample screeenshot:
![image](https://user-images.githubusercontent.com/7110965/172037642-375f17cd-ba36-45a0-909e-57300ecc6c22.png)
