### PR TITLE
Prevent generation of a card reward whenever a CustomReward is created

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/rewards/AvoidCardGenerationForCustomRewardsPatch.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/rewards/AvoidCardGenerationForCustomRewardsPatch.java
@@ -1,0 +1,36 @@
+package basemod.patches.com.megacrit.cardcrawl.rewards;
+
+import basemod.abstracts.CustomReward;
+import com.evacipated.cardcrawl.modthespire.lib.SpireInstrumentPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.rewards.RewardItem;
+import javassist.CannotCompileException;
+import javassist.expr.ExprEditor;
+import javassist.expr.MethodCall;
+
+// CustomReward calls the default (parameterless) constructor of RewardItem, which is perfectly reasonable except for
+// thing: that constructor is normally used for generating card rewards, and it calls AbstractDungeon.getRewardCards().
+// This has negative effects: it advances the rare card chance and it makes outcomes change on save/load. It's also
+// unnecessary, since custom rewards are going to do their own logic to populate whatever rewards get shown, and don't
+// need the card rewards to be populated.
+// In theory, this could also be fixed by explicitly calling a different superclass constructor in CustomReward, but all
+// the choices have their own quirks. That approach seems more likely to break things and/or take more work than than
+// this patch, which simply eliminates the harmful call for anything that's a CustomReward and has been used by a few
+// mods for a while now without any issues.
+@SpirePatch(clz = RewardItem.class, method = SpirePatch.CONSTRUCTOR, paramtypez = {})
+public class AvoidCardGenerationForCustomRewardsPatch {
+    public static class AvoidCardGenerationForCustomRewardsPatchExprEditor extends ExprEditor {
+        @Override
+        public void edit(MethodCall methodCall) throws CannotCompileException {
+            if (methodCall.getClassName().equals(AbstractDungeon.class.getName()) && methodCall.getMethodName().equals("getRewardCards")) {
+                methodCall.replace(String.format("{ $_ = this instanceof %1$s ? null : $proceed($$); }", CustomReward.class.getName()));
+            }
+        }
+    }
+
+    @SpireInstrumentPatch
+    public static ExprEditor getAvoidCardGenerationForCustomRewardsPatch() {
+        return new AvoidCardGenerationForCustomRewardsPatchExprEditor();
+    }
+}


### PR DESCRIPTION
This fixes save/load inconsistency and fixes the rare chance increasing faster than it should. Prompted by https://discord.com/channels/309399445785673728/398373038732738570/1001685904894738483.

This patch is directly adapted from one I wrote in Corrupt the Spire: https://github.com/modargo/corruptthespire/blob/master/src/main/java/corruptthespire/patches/rewards/AvoidCardGenerationForCustomRewardsPatch.java. That patch only applied to custom rewards defined by Corrupt the Spire since I didn't want my mod to have a universal effect, but now that the universal effect is desired, the BaseMod version affects all custom rewards.

The patch has a detailed comment laying out why this happens and why I think this solution is reasonable. Might be overkill but I prefer to have bug fixes like this well documented.

There were some ways to avoid the save/reload instability, if you instantiated your custom reward at the "right" time. 

I tested this locally by running a local version of Corrupt the Spire with the equivalent patch (the one linked above) removed. I got to a fight that had a corrupted card reward and tested what happened when I won that fight and saved/reloaded (restoring from a backup save file from before the fight each time).
* Current BaseMod: Saving and reloading changes the cards that are in the card rewards, is the bug that originally motivated the patch. (I tested this to serve as a control case, since it had been a long time since I made the patch and you can't know your fix worked unless you reproduce the problem first.)
* BaseMod with the new patch: Saving and reloading is stable. Also, the card rewards are different because the extra RNG advancement from the unseen card reward doesn't happen.

No particularly urgency on this, beyond it being a good bugfix that will fix oddities people are seeing in playing existing mods and developing new ones.