### PR TITLE
beta art support for custom card

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/BetaArtToggle.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/BetaArtToggle.java
@@ -1,0 +1,30 @@
+package basemod.patches.com.megacrit.cardcrawl.screens.SingleCardViewPopup;
+
+import basemod.BaseMod;
+import basemod.patches.com.megacrit.cardcrawl.screens.VictoryScreen.TrackKilledHeart;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.helpers.Prefs;
+import com.megacrit.cardcrawl.screens.SingleCardViewPopup;
+
+@SpirePatch(
+        clz = SingleCardViewPopup.class,
+        method = "canToggleBetaArt"
+)
+public class BetaArtToggle {
+    @SpirePostfixPatch
+    public static boolean otherCharacterCheck(boolean __result, SingleCardViewPopup __instance, AbstractCard ___card) {
+        if (___card != null && !__result && !BaseMod.isBaseGameCardColor(___card.color)) {
+            for (AbstractPlayer p : CardCrawlGame.characterManager.getAllCharacters()) {
+                if (p.getCardColor() == ___card.color) {
+                    Prefs playerPrefs = p.getPrefs();
+                    return playerPrefs != null && playerPrefs.getBoolean(TrackKilledHeart.HEART_KILL, false);
+                }
+            }
+        }
+        return __result;
+    }
+}

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/VictoryScreen/TrackKilledHeart.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/VictoryScreen/TrackKilledHeart.java
@@ -1,0 +1,37 @@
+package basemod.patches.com.megacrit.cardcrawl.screens.VictoryScreen;
+
+import basemod.BaseMod;
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.helpers.Prefs;
+import com.megacrit.cardcrawl.monsters.MonsterGroup;
+import com.megacrit.cardcrawl.screens.VictoryScreen;
+import javassist.CtBehavior;
+
+@SpirePatch(
+        clz = VictoryScreen.class,
+        method = SpirePatch.CONSTRUCTOR
+)
+public class TrackKilledHeart {
+    public static final String HEART_KILL = "basemod:HEART_KILL";
+
+    @SpireInsertPatch(
+            locator = Locator.class
+    )
+    public static void trackHeartKill(VictoryScreen __instance, MonsterGroup m) {
+        if (!BaseMod.isBaseGameCharacter(AbstractDungeon.player)) {
+            Prefs charPrefs = AbstractDungeon.player.getPrefs();
+            if (charPrefs != null && !charPrefs.getBoolean(HEART_KILL, false)) {
+                charPrefs.putBoolean(HEART_KILL, true);
+                charPrefs.flush();
+            }
+        }
+    }
+
+    private static class Locator extends SpireInsertLocator {
+        public int[] Locate(CtBehavior ctBehavior) throws Exception {
+            Matcher finalMatcher = new Matcher.MethodCallMatcher(Prefs.class, "flush");
+            return LineFinder.findInOrder(ctBehavior, finalMatcher);
+        }
+    }
+}


### PR DESCRIPTION
Add beta images similarly to how portrait images are added, using a _b suffix.
For portrait beta images, it is _b_p

So, for a card with image `image.png` there would be
`image.png`
`image_p.png`
`image_b.png`
`image_b_p.png`