### PR TITLE
Remove println in CustomEnergyOrb that typically prints out a 5 for each modded character on startup

### DIFF
--- a/mod/src/main/java/basemod/abstracts/CustomEnergyOrb.java
+++ b/mod/src/main/java/basemod/abstracts/CustomEnergyOrb.java
@@ -49,7 +49,6 @@ public class CustomEnergyOrb implements EnergyOrbInterface
 			assert orbTexturePaths.length % 2 == 1;
 
 			int middleIdx = orbTexturePaths.length / 2;
-			System.out.println(middleIdx);
 
 			energyLayers = new Texture[middleIdx];
 			noEnergyLayers = new Texture[middleIdx];


### PR DESCRIPTION
This is something I noticed from time to time but always ignored. I was inspired to hunt it down by the conversation at https://discord.com/channels/309399445785673728/398373038732738570/1032703676223078502.

The reason this typically prints a 5 is because the default energy orb setup (from DefaultMod) has 11 separate layers, and most mods keep that.

There's no point to having this print statement around and removing it means one less distracting thing in the logs.

No particular urgency on this since it's just cleaning up the logs.

![image](https://user-images.githubusercontent.com/62083413/197018882-3c852618-ff05-4317-8286-21eb34117c2b.png)
