### PR TITLE
Allow dynamic variables to check card instance during upgrade coloring

### DIFF
--- a/mod/src/main/java/basemod/abstracts/DynamicVariable.java
+++ b/mod/src/main/java/basemod/abstracts/DynamicVariable.java
@@ -31,6 +31,11 @@ public abstract class DynamicVariable
         return Settings.GREEN_TEXT_COLOR;
     }
 
+    public Color getUpgradedColor(AbstractCard card)
+    {
+        return null;
+    }
+
     public Color getIncreasedValueColor()
     {
         return Settings.GREEN_TEXT_COLOR;

--- a/mod/src/main/java/basemod/abstracts/DynamicVariable.java
+++ b/mod/src/main/java/basemod/abstracts/DynamicVariable.java
@@ -33,7 +33,7 @@ public abstract class DynamicVariable
 
     public Color getUpgradedColor(AbstractCard card)
     {
-        return null;
+        return getUpgradedColor();
     }
 
     public Color getIncreasedValueColor()

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderCustomDynamicVariable.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderCustomDynamicVariable.java
@@ -103,7 +103,8 @@ public class RenderCustomDynamicVariable
             if (dv != null) {
                 num = dv.baseValue(card);
                 if (dv.upgraded(card)) {
-                    c = dv.getUpgradedColor();
+                    Color instanceColor = dv.getUpgradedColor(card);
+                    c = instanceColor == null ? dv.getUpgradedColor() : instanceColor;
                 } else {
                     c = dv.getNormalColor();
                 }

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderCustomDynamicVariable.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderCustomDynamicVariable.java
@@ -103,8 +103,7 @@ public class RenderCustomDynamicVariable
             if (dv != null) {
                 num = dv.baseValue(card);
                 if (dv.upgraded(card)) {
-                    Color instanceColor = dv.getUpgradedColor(card);
-                    c = instanceColor == null ? dv.getUpgradedColor() : instanceColor;
+                    c = dv.getUpgradedColor(card);
                 } else {
                     c = dv.getNormalColor();
                 }


### PR DESCRIPTION
Allow mods to provide various upgrade colors based on card properties. Needed for DuelistMod to properly color Tribute cost upgrades that increase the Tribute cost rather than lower it.