### PR TITLE
convenience methods for phased event card selections

### DIFF
--- a/mod/src/main/java/basemod/abstracts/events/PhasedEvent.java
+++ b/mod/src/main/java/basemod/abstracts/events/PhasedEvent.java
@@ -70,6 +70,7 @@ public abstract class PhasedEvent extends AbstractImageEvent {
                 }
                 //Post-combat saves load the event based on the ID stored in the metrics data.
             }
+            next.reset();
             next.transition(this);
         }
     }
@@ -77,7 +78,7 @@ public abstract class PhasedEvent extends AbstractImageEvent {
     @Override
     protected void buttonEffect(int i) {
         if (currentPhase instanceof ImageEventPhase) {
-            ((ImageEventPhase) currentPhase).optionChosen(i);
+            ((ImageEventPhase) currentPhase).optionChosen(this, i);
         }
     }
 

--- a/mod/src/main/java/basemod/abstracts/events/phases/EventPhase.java
+++ b/mod/src/main/java/basemod/abstracts/events/phases/EventPhase.java
@@ -3,13 +3,30 @@ package basemod.abstracts.events.phases;
 import basemod.abstracts.events.PhasedEvent;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 
+import java.util.function.Consumer;
+
 public abstract class EventPhase {
+    private Consumer<EventPhase> updateHandler = null;
+
     public abstract void transition(PhasedEvent event);
     public abstract void hide(PhasedEvent event);
 
-    public void update() {
-
+    public void reset() {
+        updateHandler = null;
     }
+
+    public void setUpdateHandler(Consumer<EventPhase> handler) {
+        updateHandler = handler;
+    }
+
+    public Consumer<EventPhase> getUpdateHandler() {
+        return updateHandler;
+    }
+
+    public void update() {
+        if (updateHandler != null) updateHandler.accept(this);
+    }
+
     public void render(SpriteBatch sb) {
 
     }

--- a/mod/src/main/java/basemod/abstracts/events/phases/ImageEventPhase.java
+++ b/mod/src/main/java/basemod/abstracts/events/phases/ImageEventPhase.java
@@ -4,7 +4,12 @@ import basemod.abstracts.events.PhasedEvent;
 import com.megacrit.cardcrawl.events.GenericEventDialog;
 
 public abstract class ImageEventPhase extends EventPhase {
-    public abstract void optionChosen(int i);
+    public void optionChosen(PhasedEvent event, int i) {
+        optionChosen(i);
+    }
+    public void optionChosen(int i) {
+
+    }
 
     @Override
     public void hide(PhasedEvent event) {

--- a/mod/src/main/java/basemod/abstracts/events/phases/InteractionPhase.java
+++ b/mod/src/main/java/basemod/abstracts/events/phases/InteractionPhase.java
@@ -25,6 +25,7 @@ public class InteractionPhase extends EventPhase {
     }
     public InteractionPhase(InteractionHandler handler) {
         this.handler = handler;
+        setUpdateHandler((eventPhase -> handler.update()));
     }
 
     @Override
@@ -33,11 +34,6 @@ public class InteractionPhase extends EventPhase {
         AbstractDungeon.rs = AbstractDungeon.RenderScene.EVENT;
         event.resetCardRarity();
         handler.begin(event);
-    }
-
-    @Override
-    public void update() {
-        handler.update();
     }
 
     @Override

--- a/mod/src/main/java/basemod/abstracts/events/phases/TextPhase.java
+++ b/mod/src/main/java/basemod/abstracts/events/phases/TextPhase.java
@@ -1,27 +1,32 @@
 package basemod.abstracts.events.phases;
 
+import basemod.Pair;
 import basemod.abstracts.events.PhasedEvent;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardGroup;
+import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.events.AbstractEvent;
 import com.megacrit.cardcrawl.events.GenericEventDialog;
 import com.megacrit.cardcrawl.relics.AbstractRelic;
 import com.megacrit.cardcrawl.rooms.AbstractRoom;
+import com.megacrit.cardcrawl.vfx.UpgradeShineEffect;
+import com.megacrit.cardcrawl.vfx.cardManip.PurgeCardEffect;
+import com.megacrit.cardcrawl.vfx.cardManip.ShowCardBrieflyEffect;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public class TextPhase extends ImageEventPhase {
     private final String body;
     private final List<OptionInfo> options;
-    private final List<Consumer<Integer>> optionResults;
 
     public TextPhase(String bodyText) {
         body = bodyText;
         options = new ArrayList<>();
-        optionResults = new ArrayList<>();
     }
 
     public void transition(PhasedEvent event) {
@@ -37,25 +42,25 @@ public class TextPhase extends ImageEventPhase {
     }
 
     public TextPhase addOption(String optionText, Consumer<Integer> onClick, AbstractRelic relicReward) {
-        options.add(new OptionInfo(optionText, relicReward));
-        optionResults.add(onClick);
+        options.add(new OptionInfo(optionText, relicReward).setOptionResult(onClick));
         return this;
     }
 
     public TextPhase addOption(String optionText, Consumer<Integer> onClick) {
-        options.add(new OptionInfo(optionText));
-        optionResults.add(onClick);
+        options.add(new OptionInfo(optionText).setOptionResult(onClick));
         return this;
     }
     public TextPhase addOption(OptionInfo option, Consumer<Integer> onClick) {
+        options.add(option.setOptionResult(onClick));
+        return this;
+    }
+    public TextPhase addOption(OptionInfo option) {
         options.add(option);
-        optionResults.add(onClick);
         return this;
     }
 
     public TextPhase addOption(String optionText, AbstractRelic previewRelic, Consumer<Integer> onClick) {
-        options.add(new OptionInfo(optionText, previewRelic));
-        optionResults.add(onClick);
+        options.add(new OptionInfo(optionText, previewRelic).setOptionResult(onClick));
         return this;
     }
 
@@ -70,19 +75,23 @@ public class TextPhase extends ImageEventPhase {
         }
     }
     @Override
-    public void optionChosen(int index) {
-        if (index < optionResults.size()) {
-            optionResults.get(index).accept(index);
+    public void optionChosen(PhasedEvent event, int index) {
+        if (index < options.size()) {
+            options.get(index).choose(event, index);
         }
     }
 
     public static class OptionInfo {
+        private static final BiConsumer<PhasedEvent, Integer> emptyConsumer = (e, i)->{};
+
         private final OptionType type;
         private final String text;
         private final AbstractCard card;
         private final AbstractRelic relic;
 
-        private Supplier<Boolean> condition;
+        private final List<Pair<Supplier<Boolean>, String>> conditions = new ArrayList<>();
+
+        public BiConsumer<PhasedEvent, Integer> optionResult = emptyConsumer;
 
         public OptionInfo(String text) {
             this.type = OptionType.TEXT;
@@ -109,31 +118,138 @@ public class TextPhase extends ImageEventPhase {
             this.relic = r;
         }
         public OptionInfo enabledCondition(Supplier<Boolean> enabledCondition) {
-            this.condition = enabledCondition;
+            return enabledCondition(enabledCondition, text);
+        }
+
+        public OptionInfo enabledCondition(Supplier<Boolean> enabledCondition, String disabledText) {
+            this.conditions.add(new Pair<>(enabledCondition, disabledText));
             return this;
         }
 
-        private boolean disabled() {
-            return condition != null && !condition.get();
+        public OptionInfo setOptionResult(Consumer<Integer> optionResult) {
+            this.optionResult = (event, i)->optionResult.accept(i);
+            return this;
+        }
+        public OptionInfo setOptionResult(BiConsumer<PhasedEvent, Integer> optionResult) {
+            this.optionResult = optionResult;
+            return this;
+        }
+
+        public OptionInfo cardSelectOption(Object followupKey, Supplier<CardGroup> cardSupplier, String text, int amount, boolean forUpgrade, boolean forTransform, boolean canCancel, boolean forPurge, BiConsumer<PhasedEvent, ArrayList<AbstractCard>> result) {
+            return setOptionResult((event, i) -> {
+                Consumer<EventPhase> origHandler = event.currentPhase.getUpdateHandler();
+
+                AbstractDungeon.gridSelectScreen.open(cardSupplier.get(), amount, text, forUpgrade, forTransform, canCancel, forPurge);
+
+                event.currentPhase.setUpdateHandler(
+                        eventPhase -> {
+                            if (AbstractDungeon.isScreenUp)
+                                return;
+
+                            eventPhase.setUpdateHandler(origHandler);
+
+                            if (!AbstractDungeon.gridSelectScreen.selectedCards.isEmpty()) {
+                                result.accept(event, AbstractDungeon.gridSelectScreen.selectedCards);
+                                AbstractDungeon.gridSelectScreen.selectedCards.clear();
+                            }
+
+                            if (followupKey != null)
+                                event.transitionKey(followupKey);
+                        }
+                );
+            });
+        }
+
+        public OptionInfo cardSelectOption(Object followupKey, Supplier<CardGroup> cardSupplier, String text, int amount, boolean forUpgrade, boolean forTransform, boolean canCancel, boolean forPurge, Consumer<ArrayList<AbstractCard>> result) {
+            return cardSelectOption(followupKey, cardSupplier, text, amount, forUpgrade, forTransform, canCancel, forPurge,
+                    (event, cards)->result.accept(cards));
+        }
+
+        public OptionInfo cardUpgradeOption(Object followupKey, String upgradeText, int amount) {
+            return cardSelectOption(followupKey, ()->AbstractDungeon.player.masterDeck.getUpgradableCards(), upgradeText, amount, true, false, false, false,
+                    (event, cards)->{
+                        if (cards.size() == 1) {
+                            AbstractCard c = cards.get(0);
+                            c.upgrade();
+                            AbstractEvent.logMetricCardUpgrade(event.id, "Upgraded", c);
+                            AbstractDungeon.player.bottledCardUpgradeCheck(c);
+                            AbstractDungeon.effectsQueue.add(new ShowCardBrieflyEffect(c.makeStatEquivalentCopy()));
+                            AbstractDungeon.topLevelEffects.add(new UpgradeShineEffect((float) Settings.WIDTH / 2.0F, (float)Settings.HEIGHT / 2.0F));
+                        }
+                        else {
+                            List<String> cardUpgrades = new ArrayList<>();
+                            for (AbstractCard c : cards) {
+                                c.upgrade();
+                                cardUpgrades.add(c.cardID);
+                                AbstractDungeon.player.bottledCardUpgradeCheck(c);
+                                AbstractDungeon.effectsQueue.add(new ShowCardBrieflyEffect(c.makeStatEquivalentCopy()));
+                                AbstractDungeon.topLevelEffects.add(new UpgradeShineEffect((float) Settings.WIDTH / 2.0F, (float)Settings.HEIGHT / 2.0F));
+                            }
+                            AbstractEvent.logMetricUpgradeCards(event.id, "Upgrades", cardUpgrades);
+                        }
+                    });
+        }
+
+        public OptionInfo cardRemovalOption(Object followupKey, String removalText, int amount) {
+            return cardSelectOption(followupKey, ()->CardGroup.getGroupWithoutBottledCards(AbstractDungeon.player.masterDeck.getPurgeableCards()), removalText, amount, false, false, false, true,
+                    (event, cards)->{
+                        if (cards.size() == 1) {
+                            AbstractCard c = cards.get(0);
+                            AbstractDungeon.topLevelEffects.add(new PurgeCardEffect(c, (float) (Settings.WIDTH / 2), (float) (Settings.HEIGHT / 2)));
+                            AbstractEvent.logMetricCardRemoval(event.id, "Purged", c);
+                            AbstractDungeon.player.masterDeck.removeCard(c);
+                        }
+                        else if (cards.size() > 1) {
+                            float x = Settings.WIDTH / 2f;
+                            float offset = 0;
+                            if (cards.size() < 5) {
+                                offset = Settings.WIDTH / 6f;
+                                x -= offset * ((cards.size() - 1) / 2f);
+                            }
+
+                            List<String> removedCards = new ArrayList<>();
+                            for (AbstractCard c : cards) {
+                                AbstractDungeon.topLevelEffects.add(new PurgeCardEffect(c, x, (float) (Settings.HEIGHT / 2)));
+                                removedCards.add(c.cardID);
+                                AbstractDungeon.player.masterDeck.removeCard(c);
+                                x += offset;
+                            }
+
+                            AbstractEvent.logMetric(event.id, "Purged", null, removedCards, null, null, null, null, null, 0, 0, 0, 0, 0, 0);
+                        }
+                    });
         }
 
         public void set(GenericEventDialog dialog) {
+            boolean disabled = false;
+            String finalText = text;
+            for (Pair<Supplier<Boolean>, String> condition : conditions) {
+                if (!condition.getKey().get()) {
+                    disabled = true;
+                    finalText = condition.getValue();
+                    break;
+                }
+            }
+
             switch (type) {
                 case CARD:
-                    dialog.setDialogOption(text, disabled(), card);
+                    dialog.setDialogOption(finalText, disabled, card);
                     break;
                 case RELIC:
-                    dialog.setDialogOption(text, disabled(), relic);
+                    dialog.setDialogOption(finalText, disabled, relic);
                     break;
                 case BOTH:
-                    dialog.setDialogOption(text, disabled(), card, relic);
+                    dialog.setDialogOption(finalText, disabled, card, relic);
                     break;
                 default:
-                    dialog.setDialogOption(text, disabled());
+                    dialog.setDialogOption(finalText, disabled);
                     break;
             }
         }
 
+        public void choose(PhasedEvent event, int i) {
+            optionResult.accept(event, i);
+        }
 
         private enum OptionType {
             TEXT,


### PR DESCRIPTION
should be backwards compatible unless someone is doing something VERY weird and also messing with private stuff using reflection

adds convenience methods to perform card selection from an option without manually overriding update