### PR TITLE
- Add backend config value for adjusting ImGUI toggle key

### DIFF
--- a/mod/src/main/java/basemod/BaseMod.java
+++ b/mod/src/main/java/basemod/BaseMod.java
@@ -12,9 +12,11 @@ import basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard.RenderDescripti
 import basemod.patches.com.megacrit.cardcrawl.helpers.TopPanel.TopPanelHelper;
 import basemod.patches.com.megacrit.cardcrawl.screens.select.GridCardSelectScreen.GridCardSelectScreenFields;
 import basemod.patches.com.megacrit.cardcrawl.unlock.UnlockTracker.CountModdedUnlockCards;
+import basemod.patches.imgui.ImGuiPatches;
 import basemod.patches.whatmod.WhatMod;
 import basemod.screens.ModalChoiceScreen;
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.Version;
 import com.badlogic.gdx.files.FileHandle;
@@ -285,6 +287,7 @@ public class BaseMod {
 		defaultProperties.setProperty("basemod-fixes", Boolean.toString(true));
 		defaultProperties.setProperty("imgui-search", Boolean.toString(true));
 		defaultProperties.setProperty("imgui-actionqueue", Boolean.toString(true));
+		defaultProperties.setProperty("imgui-toggle-key", "E");
 
 		try {
 			SpireConfig retConfig = new SpireConfig(BaseModInit.MODNAME, CONFIG_FILE, defaultProperties);
@@ -343,6 +346,10 @@ public class BaseMod {
 		Boolean whatmodEnabled = getBoolean("whatmod-enabled");
 		if (whatmodEnabled != null) {
 			WhatMod.enabled = whatmodEnabled;
+		}
+		String imguiKey = getString("imgui-toggle-key");
+		if (imguiKey != null) {
+			ImGuiPatches.toggleKey = Keys.valueOf(imguiKey);
 		}
 
 		fixesEnabled = getBoolean("basemod-fixes");

--- a/mod/src/main/java/basemod/patches/imgui/ImGuiPatches.java
+++ b/mod/src/main/java/basemod/patches/imgui/ImGuiPatches.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 public class ImGuiPatches
 {
+	public static int toggleKey = Input.Keys.E;
 	private static ImGuiImplGlfw imGuiGlfw;
 	private static ImGuiImplGl3 imGuiGl3;
 
@@ -100,8 +101,8 @@ public class ImGuiPatches
 
 			SuppressHotkey.suppressedKeys.clear();
 
-			if (Gdx.input.isKeyPressed(Input.Keys.SHIFT_LEFT) && Gdx.input.isKeyJustPressed(Input.Keys.E)) {
-				SuppressHotkey.suppressedKeys.add(Input.Keys.E);
+			if (Gdx.input.isKeyPressed(Input.Keys.SHIFT_LEFT) && Gdx.input.isKeyJustPressed(toggleKey)) {
+				SuppressHotkey.suppressedKeys.add(toggleKey);
 				enabled = !enabled;
 				GameCursor.hidden = enabled;
 			}


### PR DESCRIPTION
This PR adds a config value called "imgui-toggle-key" that determines what key (in conjunction with Shift) needs to be pressed to toggle ImGUI on or off.

For now, this is only editable in the backend (i.e. adding something like `imgui-toggle-key=[` to the basemod-config.properties file in your AppData folder, but I can follow up with a frontend config item if desired.