### PR TITLE
fix capitalized prefixes, improve keyword rendering, refactor cardmod base value  changes

### DIFF
--- a/mod/src/main/java/basemod/BaseMod.java
+++ b/mod/src/main/java/basemod/BaseMod.java
@@ -990,8 +990,9 @@ public class BaseMod {
 	 */
 	public static float calculateCardDamage(AbstractPlayer player, AbstractMonster mo, AbstractCard c, float tmp) {
 		if (c instanceof CustomCard) {
+			float oldVal = tmp;
 			float newVal = ((CustomCard) c).calculateModifiedCardDamage(player, mo, tmp);
-			if ((int) newVal != c.baseDamage) {
+			if (newVal != oldVal) {
 				c.isDamageModified = true;
 			}
 			return newVal;

--- a/mod/src/main/java/basemod/abstracts/DynamicVariable.java
+++ b/mod/src/main/java/basemod/abstracts/DynamicVariable.java
@@ -4,8 +4,12 @@ import com.badlogic.gdx.graphics.Color;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.core.Settings;
 
+import java.util.regex.Pattern;
+
 public abstract class DynamicVariable
 {
+    public static Pattern variablePattern = Pattern.compile("(.*)!(.+)!(.*)");
+
     public abstract String key();
 
     public abstract boolean isModified(AbstractCard card);

--- a/mod/src/main/java/basemod/abstracts/DynamicVariable.java
+++ b/mod/src/main/java/basemod/abstracts/DynamicVariable.java
@@ -24,7 +24,9 @@ public abstract class DynamicVariable
 
     public abstract int baseValue(AbstractCard card);
 
-    public final int modifiedBaseValue(AbstractCard card) {
+    //Only affects the standard damage, block, and magicNumber variables normally.
+    //Can be overriden to do custom modification of base value for a custom variable.
+    public int modifiedBaseValue(AbstractCard card) {
         int base = baseValue(card);
 
         base = CardModifierManager.modifiedBaseValue(card, base, key());

--- a/mod/src/main/java/basemod/abstracts/DynamicVariable.java
+++ b/mod/src/main/java/basemod/abstracts/DynamicVariable.java
@@ -1,5 +1,6 @@
 package basemod.abstracts;
 
+import basemod.helpers.CardModifierManager;
 import com.badlogic.gdx.graphics.Color;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.core.Settings;
@@ -22,6 +23,14 @@ public abstract class DynamicVariable
     public abstract int value(AbstractCard card);
 
     public abstract int baseValue(AbstractCard card);
+
+    public final int modifiedBaseValue(AbstractCard card) {
+        int base = baseValue(card);
+
+        base = CardModifierManager.modifiedBaseValue(card, base, key());
+
+        return base;
+    }
 
     public abstract boolean upgraded(AbstractCard card);
 

--- a/mod/src/main/java/basemod/helpers/ModalChoice.java
+++ b/mod/src/main/java/basemod/helpers/ModalChoice.java
@@ -91,7 +91,7 @@ public class ModalChoice
                     if (dv.isModified(card)) {
                         num = dv.value(card);
                     } else {
-                        num = dv.baseValue(card);
+                        num = dv.modifiedBaseValue(card);
                     }
                 }
                 stringBuilder.append(num);

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderCustomDynamicVariable.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderCustomDynamicVariable.java
@@ -48,7 +48,7 @@ public class RenderCustomDynamicVariable
                 if (rounded && m.getMethodName().equals("charAt")) {
                     m.replace(
                             "if (" + Inner.class.getName() + ".checkDynamicVariable(tmp)) {" +
-                                        "start_x += " + Inner.class.getName() + ".myRenderDynamicVariable(this, tmp, start_x, draw_y, i, font, sb);" +
+                                        "start_x += " + Inner.class.getName() + ".renderDynamicVariable(this, tmp, start_x, draw_y, i, font, sb);" +
                                         "tmp = \"!\";" +
                                         "$_ = '!';" +
                                     "}" +
@@ -79,12 +79,13 @@ public class RenderCustomDynamicVariable
             return false;
         }
 
+        //Old method left for compatibility
         public static float myRenderDynamicVariable(Object __obj_instance, String key, char ckey, float start_x, float draw_y, int i, BitmapFont font, SpriteBatch sb, Character cend) {
 
             return subRenderDynamicVariable(__obj_instance, "", "" + ckey, (cend == null ? "" : "" + cend), start_x, draw_y, i, font, sb);
         }
 
-        public static float myRenderDynamicVariable(Object __obj_instance, String key, float start_x, float draw_y, int i, BitmapFont font, SpriteBatch sb)
+        public static float renderDynamicVariable(Object __obj_instance, String key, float start_x, float draw_y, int i, BitmapFont font, SpriteBatch sb)
         {
             String pre = "", end = "";
 
@@ -113,48 +114,16 @@ public class RenderCustomDynamicVariable
             if (dv != null) {
                 if (dv.isModified(__instance)) {
                     num = dv.value(__instance);
-                    if (num >= dv.baseValue(__instance)) {
+                    if (num >= dv.modifiedBaseValue(__instance)) {
                         c = dv.getIncreasedValueColor();
                     } else {
                         c = dv.getDecreasedValueColor();
                     }
                 } else {
                     c = dv.getNormalColor();
-                    num = dv.baseValue(__instance);
+                    num = dv.modifiedBaseValue(__instance);
                 }
-                //cardmods affect base variables
-                int base = -1;
-                boolean modified = false;
-                if (CardModifierPatches.CardModifierFields.needsRecalculation.get(__instance)) {
-                    CardModifierManager.testBaseValues(__instance);
-                    CardModifierPatches.CardModifierFields.needsRecalculation.set(__instance, false);
-                }
-                if (dv instanceof BlockVariable && CardModifierPatches.CardModifierFields.cardModHasBaseBlock.get(__instance)) {
-                    base = CardModifierPatches.CardModifierFields.cardModBaseBlock.get(__instance);
-                    modified = true;
-                } else if (dv instanceof DamageVariable && CardModifierPatches.CardModifierFields.cardModHasBaseDamage.get(__instance)) {
-                    base = CardModifierPatches.CardModifierFields.cardModBaseDamage.get(__instance);
-                    modified = true;
-                } else if (dv instanceof MagicNumberVariable && CardModifierPatches.CardModifierFields.cardModHasBaseMagic.get(__instance)) {
-                    base = CardModifierPatches.CardModifierFields.cardModBaseMagic.get(__instance);
-                    modified = true;
-                }
-                if (modified) {
-                    if (!CardModifierPatches.CardModifierFields.preCalculated.get(__instance)) {
-                        num = base;
-                    }
-                    if (CardModifierPatches.CardModifierFields.previewingUpgrade.get(__instance)) {
-                        c = dv.getIncreasedValueColor();
-                    } else {
-                        if (num == base) {
-                            c = dv.getNormalColor();
-                        } else if (num > base) {
-                            c = dv.getIncreasedValueColor();
-                        } else {
-                            c = dv.getDecreasedValueColor();
-                        }
-                    }
-                }
+
                 c = c.cpy();
                 c.a = textColor.a;
             } else {

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderCustomDynamicVariable.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderCustomDynamicVariable.java
@@ -1,6 +1,7 @@
 package basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard;
 
 import basemod.BaseMod;
+import basemod.ReflectionHacks;
 import basemod.abstracts.DynamicVariable;
 import basemod.helpers.CardModifierManager;
 import basemod.helpers.dynamicvariables.BlockVariable;
@@ -12,7 +13,6 @@ import com.badlogic.gdx.graphics.g2d.GlyphLayout;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
 import com.megacrit.cardcrawl.cards.AbstractCard;
-import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.helpers.FontHelper;
 import javassist.CannotCompileException;
 import javassist.CtBehavior;
@@ -21,9 +21,7 @@ import javassist.expr.MethodCall;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.lang.reflect.Field;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @SpirePatch(
         clz=AbstractCard.class,
@@ -33,26 +31,33 @@ public class RenderCustomDynamicVariable
 {
     public static void Raw(CtBehavior ctMethodToPatch) throws CannotCompileException
     {
-        final int[] insertLine = {-1};
         ctMethodToPatch.instrument(new ExprEditor() {
+            boolean rounded = false;
+            boolean modified = false;
+
             @Override
-            public void edit(MethodCall m) throws CannotCompileException
-            {
-                if (m.getMethodName().equals("renderDynamicVariable")) {
-                    if (insertLine[0] == -1) {
-                        insertLine[0] = m.getLineNumber();
-                    }
-                    m.replace("$_ = " + Inner.class.getName() + ".myRenderDynamicVariable(this, tmp, $$);");
+            public void edit(MethodCall m) throws CannotCompileException {
+                if (modified)
+                    return;
+
+                if (rounded && m.getMethodName().equals("charAt")) {
+                    m.replace(
+                            "if (" + Inner.class.getName() + ".checkDynamicVariable(tmp)) {" +
+                                        "start_x += " + Inner.class.getName() + ".myRenderDynamicVariable(this, tmp, start_x, draw_y, i, font, sb);" +
+                                        "tmp = \"!\";" +
+                                        "$_ = '!';" +
+                                    "}" +
+                                    "else {" +
+                                        "$_ = $proceed($$);" +
+                                    "}"
+                    );
+                    modified = true;
+                }
+                else if (m.getMethodName().equals("round")) {
+                    rounded = true;
                 }
             }
         });
-
-        if (insertLine[0] > 0) {
-            ctMethodToPatch.insertAt(insertLine[0]-1,
-                    "if (tmp.length() != 4 && tmp.length() != 5) {" +
-                            "start_x += " + Inner.class.getName() + ".myRenderDynamicVariable(this, tmp, tmp.charAt(1), start_x, draw_y, i, font, sb, null);" +
-                            "}");
-        }
     }
 
     public static class Inner
@@ -60,30 +65,35 @@ public class RenderCustomDynamicVariable
         private static Logger logger = LogManager.getLogger();
         private static final GlyphLayout gl = new GlyphLayout();
 
-        public static float myRenderDynamicVariable(Object __obj_instance, String key, char ckey, float start_x, float draw_y, int i, BitmapFont font, SpriteBatch sb, Character cend)
+        public static boolean checkDynamicVariable(String key) {
+            Matcher matcher = DynamicVariable.variablePattern.matcher(key);
+            if (matcher.find()) {
+                key = matcher.group(2);
+                return BaseMod.cardDynamicVariableMap.containsKey(key);
+            }
+            return false;
+        }
+
+
+        public static float myRenderDynamicVariable(Object __obj_instance, String key, char ckey, float start_x, float draw_y, int i, BitmapFont font, SpriteBatch sb, Character cend) {
+            return myRenderDynamicVariable(__obj_instance, key, start_x, draw_y, i, font, sb);
+        }
+        public static float myRenderDynamicVariable(Object __obj_instance, String key, float start_x, float draw_y, int i, BitmapFont font, SpriteBatch sb)
         {
             AbstractCard __instance = (AbstractCard) __obj_instance;
             // Get any private variables we need
-            Color textColor = Settings.CREAM_COLOR;
-            try {
-                Field f = AbstractCard.class.getDeclaredField("textColor");
-                f.setAccessible(true);
-                textColor = (Color) f.get(__instance);
-            } catch (IllegalAccessException | NoSuchFieldException e) {
-                e.printStackTrace();
-            }
+            Color textColor = ReflectionHacks.getPrivate(__instance, AbstractCard.class, "textColor");
 
-            String end = "";
+            String pre = "", end = "";
 
-            Pattern pattern = Pattern.compile("!(.+)!(.*) ");
-            Matcher matcher = pattern.matcher(key);
+            Matcher matcher = DynamicVariable.variablePattern.matcher(key);
             if (matcher.find()) {
-                key = matcher.group(1);
-                end = matcher.group(2);
+                pre = matcher.group(1);
+                key = matcher.group(2);
+                end = matcher.group(3);
             }
 
             // Main body of method
-            StringBuilder stringBuilder = new StringBuilder();
             Color c;
             int num = 0;
             DynamicVariable dv = BaseMod.cardDynamicVariableMap.get(key);
@@ -132,31 +142,50 @@ public class RenderCustomDynamicVariable
                         }
                     }
                 }
+                c = c.cpy();
+                c.a = textColor.a;
             } else {
                 logger.error("No dynamic card variable found for key \"" + key + "\"!");
                 c = textColor;
             }
-            c = c.cpy();
-            c.a = textColor.a;
 
-            stringBuilder.append(num);
-            gl.setText(font, stringBuilder.toString());
-            FontHelper.renderRotatedText(sb, font, stringBuilder.toString(),
+            float totalWidth = 0;
+            String variableValue = Integer.toString(num);
+
+            if (!pre.isEmpty()) {
+                gl.setText(font, pre);
+                FontHelper.renderRotatedText(sb, font, pre,
+                        __instance.current_x, __instance.current_y,
+                        start_x - __instance.current_x + gl.width / 2.0f,
+                        i * 1.45f * -font.getCapHeight() + draw_y - __instance.current_y + -6.0f,
+                        __instance.angle, true, textColor);
+
+                totalWidth += gl.width;
+                start_x += gl.width;
+            }
+
+            gl.setText(font, variableValue);
+            FontHelper.renderRotatedText(sb, font, variableValue,
                     __instance.current_x, __instance.current_y,
                     start_x - __instance.current_x + gl.width / 2.0f,
                     i * 1.45f * -font.getCapHeight() + draw_y - __instance.current_y + -6.0f,
                     __instance.angle, true, c);
+
+            totalWidth += gl.width;
+            start_x += gl.width;
+
             if (!end.isEmpty()) {
+                gl.setText(font, end);
                 FontHelper.renderRotatedText(sb, font, end,
                         __instance.current_x, __instance.current_y,
-                        start_x - __instance.current_x + gl.width + 4.0f * Settings.scale,
+                        start_x - __instance.current_x + gl.width / 2.0f,
                         i * 1.45f * -font.getCapHeight() + draw_y - __instance.current_y + -6.0f,
-                        0.0f, true, textColor);
-                stringBuilder.append(end);
+                        __instance.angle, true, textColor);
+
+                totalWidth += gl.width;
             }
-            stringBuilder.append(' ');
-            gl.setText(font, stringBuilder.toString());
-            return gl.width;
+
+            return totalWidth;
         }
     }
 }

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderCustomDynamicVariable.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderCustomDynamicVariable.java
@@ -37,6 +37,11 @@ public class RenderCustomDynamicVariable
 
             @Override
             public void edit(MethodCall m) throws CannotCompileException {
+                if (m.getMethodName().equals("renderDynamicVariable")) {
+                    m.replace("$_ = " + Inner.class.getName() + ".myRenderDynamicVariable(this, tmp, $$);");
+                    return;
+                }
+
                 if (modified)
                     return;
 
@@ -74,16 +79,13 @@ public class RenderCustomDynamicVariable
             return false;
         }
 
-
         public static float myRenderDynamicVariable(Object __obj_instance, String key, char ckey, float start_x, float draw_y, int i, BitmapFont font, SpriteBatch sb, Character cend) {
-            return myRenderDynamicVariable(__obj_instance, key, start_x, draw_y, i, font, sb);
+
+            return subRenderDynamicVariable(__obj_instance, "", "" + ckey, (cend == null ? "" : "" + cend), start_x, draw_y, i, font, sb);
         }
+
         public static float myRenderDynamicVariable(Object __obj_instance, String key, float start_x, float draw_y, int i, BitmapFont font, SpriteBatch sb)
         {
-            AbstractCard __instance = (AbstractCard) __obj_instance;
-            // Get any private variables we need
-            Color textColor = ReflectionHacks.getPrivate(__instance, AbstractCard.class, "textColor");
-
             String pre = "", end = "";
 
             Matcher matcher = DynamicVariable.variablePattern.matcher(key);
@@ -92,6 +94,17 @@ public class RenderCustomDynamicVariable
                 key = matcher.group(2);
                 end = matcher.group(3);
             }
+
+            return subRenderDynamicVariable(__obj_instance, pre, key, end, start_x, draw_y, i, font, sb);
+        }
+
+        @SuppressWarnings("ConstantConditions")
+        private static float subRenderDynamicVariable(Object __obj_instance, String pre, String key, String end, float start_x, float draw_y, int i, BitmapFont font, SpriteBatch sb)
+        {
+            AbstractCard __instance = (AbstractCard) __obj_instance;
+
+            // Get any private variables we need
+            Color textColor = ReflectionHacks.getPrivate(__instance, AbstractCard.class, "textColor");
 
             // Main body of method
             Color c;

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderCustomDynamicVariableCN.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderCustomDynamicVariableCN.java
@@ -37,20 +37,13 @@ public class RenderCustomDynamicVariableCN
 			DynamicVariable dv = BaseMod.cardDynamicVariableMap.get(key);
 			if (dv != null) {
 				if (dv.isModified(__instance)) {
-					if (dv.value(__instance) >= dv.baseValue(__instance)) {
+					if (dv.value(__instance) >= dv.modifiedBaseValue(__instance)) {
 						tmp[0] = "[#" + dv.getIncreasedValueColor().toString() + "]" + Integer.toString(dv.value(__instance)) + "[]";
 					} else {
 						tmp[0] = "[#" + dv.getDecreasedValueColor().toString() + "]" + Integer.toString(dv.value(__instance)) + "[]";
 					}
 				} else {
-					//cardmods affect base variables
-					int num = dv.baseValue(__instance);
-					if (dv instanceof BlockVariable && CardModifierPatches.CardModifierFields.cardModHasBaseBlock.get(__instance) && !__instance.isBlockModified) {
-						num = CardModifierPatches.CardModifierFields.cardModBaseBlock.get(__instance);
-					} else if (dv instanceof DamageVariable && CardModifierPatches.CardModifierFields.cardModHasBaseDamage.get(__instance) && !__instance.isDamageModified) {
-						num = CardModifierPatches.CardModifierFields.cardModBaseDamage.get(__instance);
-					}
-					tmp[0] = Integer.toString(num);
+					tmp[0] = Integer.toString(dv.modifiedBaseValue(__instance));
 				}
 			}
 		}

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderCustomDynamicVariable.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderCustomDynamicVariable.java
@@ -40,6 +40,11 @@ public class RenderCustomDynamicVariable
 
             @Override
             public void edit(MethodCall m) throws CannotCompileException {
+                if (m.getMethodName().equals("renderDynamicVariable")) {
+                    m.replace("$_ = " + Inner.class.getName() + ".myRenderDynamicVariable(this, tmp, $$);");
+                    return;
+                }
+
                 if (modified)
                     return;
 
@@ -78,18 +83,12 @@ public class RenderCustomDynamicVariable
         }
 
         public static float myRenderDynamicVariable(Object __obj_instance, String key, char ckey, float start_x, float draw_y, int i, BitmapFont font, SpriteBatch sb, Character cend) {
-            return myRenderDynamicVariable(__obj_instance, key, start_x, draw_y, i, font, sb);
+
+            return subRenderDynamicVariable(__obj_instance, "", "" + ckey, (cend == null ? "" : "" + cend), start_x, draw_y, i, font, sb);
         }
-        @SuppressWarnings("ConstantConditions")
+
         public static float myRenderDynamicVariable(Object __obj_instance, String key, float start_x, float draw_y, int i, BitmapFont font, SpriteBatch sb)
         {
-            SingleCardViewPopup __instance = (SingleCardViewPopup) __obj_instance;
-
-            // Get any private variables we need
-            AbstractCard card = ReflectionHacks.getPrivate(__instance, SingleCardViewPopup.class, "card");
-            float current_x = ReflectionHacks.getPrivate(__instance, SingleCardViewPopup.class, "current_x");
-            float current_y = ReflectionHacks.getPrivate(__instance, SingleCardViewPopup.class, "current_y");
-
             String pre = "", end = "";
 
             Matcher matcher = DynamicVariable.variablePattern.matcher(key);
@@ -98,6 +97,18 @@ public class RenderCustomDynamicVariable
                 key = matcher.group(2);
                 end = matcher.group(3);
             }
+
+            return subRenderDynamicVariable(__obj_instance, pre, key, end, start_x, draw_y, i, font, sb);
+        }
+
+        @SuppressWarnings("ConstantConditions")
+        private static float subRenderDynamicVariable(Object __obj_instance, String pre, String key, String end, float start_x, float draw_y, int i, BitmapFont font, SpriteBatch sb) {
+            SingleCardViewPopup __instance = (SingleCardViewPopup) __obj_instance;
+
+            // Get any private variables we need
+            AbstractCard card = ReflectionHacks.getPrivate(__instance, SingleCardViewPopup.class, "card");
+            float current_x = ReflectionHacks.getPrivate(__instance, SingleCardViewPopup.class, "current_x");
+            float current_y = ReflectionHacks.getPrivate(__instance, SingleCardViewPopup.class, "current_y");
 
             // Main body of method
             Color c = Settings.CREAM_COLOR;

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderCustomDynamicVariable.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderCustomDynamicVariable.java
@@ -51,7 +51,7 @@ public class RenderCustomDynamicVariable
                 if (rounded && m.getMethodName().equals("charAt")) {
                     m.replace(
                             "if (" + Inner.class.getName() + ".checkDynamicVariable(tmp)) {" +
-                                    "start_x += " + Inner.class.getName() + ".myRenderDynamicVariable(this, tmp, start_x, draw_y, i, font, sb);" +
+                                    "start_x += " + Inner.class.getName() + ".renderDynamicVariable(this, tmp, start_x, draw_y, i, font, sb);" +
                                     "tmp = \"!\";" +
                                     "$_ = '!';" +
                                     "}" +
@@ -82,12 +82,13 @@ public class RenderCustomDynamicVariable
             return false;
         }
 
+        //Old method left for compatibility
         public static float myRenderDynamicVariable(Object __obj_instance, String key, char ckey, float start_x, float draw_y, int i, BitmapFont font, SpriteBatch sb, Character cend) {
 
             return subRenderDynamicVariable(__obj_instance, "", "" + ckey, (cend == null ? "" : "" + cend), start_x, draw_y, i, font, sb);
         }
 
-        public static float myRenderDynamicVariable(Object __obj_instance, String key, float start_x, float draw_y, int i, BitmapFont font, SpriteBatch sb)
+        public static float renderDynamicVariable(Object __obj_instance, String key, float start_x, float draw_y, int i, BitmapFont font, SpriteBatch sb)
         {
             String pre = "", end = "";
 
@@ -115,7 +116,7 @@ public class RenderCustomDynamicVariable
             int num = 0;
             DynamicVariable dv = BaseMod.cardDynamicVariableMap.get(key);
             if (dv != null) {
-                num = dv.baseValue(card);
+                num = dv.modifiedBaseValue(card);
                 if (dv.upgraded(card)) {
                     c = dv.getUpgradedColor(card);
                 } else {
@@ -123,40 +124,6 @@ public class RenderCustomDynamicVariable
                 }
             } else {
                 logger.error("No dynamic card variable found for key \"" + key + "\"!");
-            }
-
-            //cardmods affect base variables
-            int base = -1;
-            boolean modified = false;
-            if (CardModifierPatches.CardModifierFields.needsRecalculation.get(card)) {
-                CardModifierManager.testBaseValues(card);
-                CardModifierPatches.CardModifierFields.needsRecalculation.set(card, false);
-            }
-            if (dv instanceof BlockVariable && CardModifierPatches.CardModifierFields.cardModHasBaseBlock.get(card)) {
-                base = CardModifierPatches.CardModifierFields.cardModBaseBlock.get(card);
-                modified = true;
-            } else if (dv instanceof DamageVariable && CardModifierPatches.CardModifierFields.cardModHasBaseDamage.get(card)) {
-                base = CardModifierPatches.CardModifierFields.cardModBaseDamage.get(card);
-                modified = true;
-            } else if (dv instanceof MagicNumberVariable && CardModifierPatches.CardModifierFields.cardModHasBaseMagic.get(card)) {
-                base = CardModifierPatches.CardModifierFields.cardModBaseMagic.get(card);
-                modified = true;
-            }
-            if (modified) {
-                if (!CardModifierPatches.CardModifierFields.preCalculated.get(card)) {
-                    num = base;
-                }
-                if (CardModifierPatches.CardModifierFields.previewingUpgrade.get(card)) {
-                    c = dv.getIncreasedValueColor();
-                } else {
-                    if (num == base) {
-                        c = dv.getNormalColor();
-                    } else if (num > base) {
-                        c = dv.getIncreasedValueColor();
-                    } else {
-                        c = dv.getDecreasedValueColor();
-                    }
-                }
             }
 
             float totalWidth = 0;

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderCustomDynamicVariable.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderCustomDynamicVariable.java
@@ -25,7 +25,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.lang.reflect.Field;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @SpirePatch(
         clz=SingleCardViewPopup.class,
@@ -35,26 +34,33 @@ public class RenderCustomDynamicVariable
 {
     public static void Raw(CtBehavior ctMethodToPatch) throws CannotCompileException
     {
-        final int[] insertLine = {-1};
         ctMethodToPatch.instrument(new ExprEditor() {
+            boolean rounded = false;
+            boolean modified = false;
+
             @Override
-            public void edit(MethodCall m) throws CannotCompileException
-            {
-                if (m.getMethodName().equals("renderDynamicVariable")) {
-                    if (insertLine[0] == -1) {
-                        insertLine[0] = m.getLineNumber();
-                    }
-                    m.replace("$_ = basemod.patches.com.megacrit.cardcrawl.screens.SingleCardViewPopup.RenderCustomDynamicVariable.Inner.myRenderDynamicVariable(this, tmp, $$);");
+            public void edit(MethodCall m) throws CannotCompileException {
+                if (modified)
+                    return;
+
+                if (rounded && m.getMethodName().equals("charAt")) {
+                    m.replace(
+                            "if (" + Inner.class.getName() + ".checkDynamicVariable(tmp)) {" +
+                                    "start_x += " + Inner.class.getName() + ".myRenderDynamicVariable(this, tmp, start_x, draw_y, i, font, sb);" +
+                                    "tmp = \"!\";" +
+                                    "$_ = '!';" +
+                                    "}" +
+                                    "else {" +
+                                    "$_ = $proceed($$);" +
+                                    "}"
+                    );
+                    modified = true;
+                }
+                else if (m.getMethodName().equals("round")) {
+                    rounded = true;
                 }
             }
         });
-
-        if (insertLine[0] > 0) {
-            ctMethodToPatch.insertAt(insertLine[0]-1,
-                    "if (tmp.length() != 4 && tmp.length() != 5) {" +
-                            "start_x += basemod.patches.com.megacrit.cardcrawl.screens.SingleCardViewPopup.RenderCustomDynamicVariable.Inner.myRenderDynamicVariable(this, tmp, tmp.charAt(1), start_x, draw_y, i, font, sb, null);" +
-                            "}");
-        }
     }
 
     public static class Inner
@@ -62,7 +68,19 @@ public class RenderCustomDynamicVariable
         private static Logger logger = LogManager.getLogger();
         private static final GlyphLayout gl = new GlyphLayout();
 
-        public static float myRenderDynamicVariable(Object __obj_instance, String key, char ckey, float start_x, float draw_y, int i, BitmapFont font, SpriteBatch sb, Character cend)
+        public static boolean checkDynamicVariable(String key) {
+            Matcher matcher = DynamicVariable.variablePattern.matcher(key);
+            if (matcher.find()) {
+                key = matcher.group(2);
+                return BaseMod.cardDynamicVariableMap.containsKey(key);
+            }
+            return false;
+        }
+
+        public static float myRenderDynamicVariable(Object __obj_instance, String key, char ckey, float start_x, float draw_y, int i, BitmapFont font, SpriteBatch sb, Character cend) {
+            return myRenderDynamicVariable(__obj_instance, key, start_x, draw_y, i, font, sb);
+        }
+        public static float myRenderDynamicVariable(Object __obj_instance, String key, float start_x, float draw_y, int i, BitmapFont font, SpriteBatch sb)
         {
             SingleCardViewPopup __instance = (SingleCardViewPopup) __obj_instance;
 
@@ -87,17 +105,16 @@ public class RenderCustomDynamicVariable
                 return 0;
             }
 
-            String end = "";
+            String pre = "", end = "";
 
-            Pattern pattern = Pattern.compile("!(.+)!(.*) ");
-            Matcher matcher = pattern.matcher(key);
+            Matcher matcher = DynamicVariable.variablePattern.matcher(key);
             if (matcher.find()) {
-                key = matcher.group(1);
-                end = matcher.group(2);
+                pre = matcher.group(1);
+                key = matcher.group(2);
+                end = matcher.group(3);
             }
 
             // Main body of method
-            StringBuilder stringBuilder = new StringBuilder();
             Color c = Settings.CREAM_COLOR;
             int num = 0;
             DynamicVariable dv = BaseMod.cardDynamicVariableMap.get(key);
@@ -146,24 +163,43 @@ public class RenderCustomDynamicVariable
                 }
             }
 
-            stringBuilder.append(num);
-            gl.setText(font, stringBuilder.toString());
-            FontHelper.renderRotatedText(sb, font, stringBuilder.toString(),
+            float totalWidth = 0;
+            String variableValue = Integer.toString(num);
+
+            if (!pre.isEmpty()) {
+                gl.setText(font, pre);
+                FontHelper.renderRotatedText(sb, font, pre,
+                        current_x, current_y,
+                        start_x - current_x + gl.width / 2.0f,
+                        i * 1.53f * -font.getCapHeight() + draw_y - current_y + -12.0f,
+                        0.0f, true, Settings.CREAM_COLOR);
+
+                totalWidth += gl.width;
+                start_x += gl.width;
+            }
+
+            gl.setText(font, variableValue);
+            FontHelper.renderRotatedText(sb, font, variableValue,
                     current_x, current_y,
                     start_x - current_x + gl.width / 2.0f,
                     i * 1.53f * -font.getCapHeight() + draw_y - current_y + -12.0f,
                     0.0f, true, c);
-            if (end != null) {
+
+            totalWidth += gl.width;
+            start_x += gl.width;
+
+            if (!end.isEmpty()) {
+                gl.setText(font, end);
                 FontHelper.renderRotatedText(sb, font, end,
                         current_x, current_y,
-                        start_x - current_x + gl.width + 10.0f * Settings.scale,
+                        start_x - current_x + gl.width / 2.0f,
                         i * 1.53f * -font.getCapHeight() + draw_y - current_y + -12.0f,
                         0.0f, true, Settings.CREAM_COLOR);
-                stringBuilder.append(end);
+
+                totalWidth += gl.width;
             }
-            stringBuilder.append(' ');
-            gl.setText(font, stringBuilder.toString());
-            return gl.width;
+
+            return totalWidth;
         }
     }
 }

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderCustomDynamicVariable.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderCustomDynamicVariable.java
@@ -1,6 +1,7 @@
 package basemod.patches.com.megacrit.cardcrawl.screens.SingleCardViewPopup;
 
 import basemod.BaseMod;
+import basemod.ReflectionHacks;
 import basemod.abstracts.DynamicVariable;
 import basemod.helpers.CardModifierManager;
 import basemod.helpers.dynamicvariables.BlockVariable;
@@ -23,7 +24,6 @@ import javassist.expr.MethodCall;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.lang.reflect.Field;
 import java.util.regex.Matcher;
 
 @SpirePatch(
@@ -80,30 +80,15 @@ public class RenderCustomDynamicVariable
         public static float myRenderDynamicVariable(Object __obj_instance, String key, char ckey, float start_x, float draw_y, int i, BitmapFont font, SpriteBatch sb, Character cend) {
             return myRenderDynamicVariable(__obj_instance, key, start_x, draw_y, i, font, sb);
         }
+        @SuppressWarnings("ConstantConditions")
         public static float myRenderDynamicVariable(Object __obj_instance, String key, float start_x, float draw_y, int i, BitmapFont font, SpriteBatch sb)
         {
             SingleCardViewPopup __instance = (SingleCardViewPopup) __obj_instance;
 
             // Get any private variables we need
-            AbstractCard card;
-            float current_x;
-            float current_y;
-            try {
-                Field f = SingleCardViewPopup.class.getDeclaredField("card");
-                f.setAccessible(true);
-                card = (AbstractCard) f.get(__instance);
-
-                f = SingleCardViewPopup.class.getDeclaredField("current_x");
-                f.setAccessible(true);
-                current_x = f.getFloat(__instance);
-
-                f = SingleCardViewPopup.class.getDeclaredField("current_y");
-                f.setAccessible(true);
-                current_y = f.getFloat(__instance);
-            } catch (IllegalAccessException | NoSuchFieldException e) {
-                e.printStackTrace();
-                return 0;
-            }
+            AbstractCard card = ReflectionHacks.getPrivate(__instance, SingleCardViewPopup.class, "card");
+            float current_x = ReflectionHacks.getPrivate(__instance, SingleCardViewPopup.class, "current_x");
+            float current_y = ReflectionHacks.getPrivate(__instance, SingleCardViewPopup.class, "current_y");
 
             String pre = "", end = "";
 

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderCustomDynamicVariableCN.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderCustomDynamicVariableCN.java
@@ -39,20 +39,14 @@ public class RenderCustomDynamicVariableCN
 			DynamicVariable dv = BaseMod.cardDynamicVariableMap.get(key);
 			if (dv != null) {
 				if (dv.isModified(card)) {
-					if (dv.value(card) >= dv.baseValue(card)) {
+					if (dv.value(card) >= dv.modifiedBaseValue(card)) {
 						tmp[0] = "[#" + dv.getIncreasedValueColor().toString() + "]" + Integer.toString(dv.value(card)) + "[]";
 					} else {
 						tmp[0] = "[#" + dv.getDecreasedValueColor().toString() + "]" + Integer.toString(dv.value(card)) + "[]";
 					}
 				} else {
 					//cardmods affect base variables
-					int num = dv.baseValue(card);
-					if (dv instanceof BlockVariable && CardModifierPatches.CardModifierFields.cardModHasBaseBlock.get(card) && (!card.isBlockModified || card.upgradedBlock) ) {
-						num = CardModifierPatches.CardModifierFields.cardModBaseBlock.get(card);
-					} else if (dv instanceof DamageVariable && CardModifierPatches.CardModifierFields.cardModHasBaseDamage.get(card) && (!card.isDamageModified || card.upgradedDamage)) {
-						num = CardModifierPatches.CardModifierFields.cardModBaseDamage.get(card);
-					}
-					tmp[0] = Integer.toString(num);
+					tmp[0] = Integer.toString(dv.modifiedBaseValue(card));
 				}
 			}
 		}


### PR DESCRIPTION
fix offset of capitalized prefixes and also make it more efficient by inserting into keyword part of initializeDescription and only testing actual keywords

use ReflectionHacks instead of getting fields each frame for variable rendering, allow variables in not CN to be used in the middle/at the end of words
just use one pattern instead of making a bunch

Didn't touch CN rendering because I Do Not know how it works in detail.


cardmod base value changes - Mostly functions similar, should just be more consistent.
Actual base variables remain unchanged, damage/block calculation was changed to use instrument patches to reference modified base value instead of original base value
Text rendering utilizes the fact that basemod's dynamic variable system replaces the original variable rendering to get the base value there