### PR TITLE
Add ModRadioButtonGroup + ModToggleButton.addConsumer()

### DIFF
--- a/mod/src/main/java/basemod/ModRadioButtonGroup.java
+++ b/mod/src/main/java/basemod/ModRadioButtonGroup.java
@@ -1,0 +1,43 @@
+package basemod;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ModRadioButtonGroup {
+    private List<ModToggleButton> buttons;
+    private ModToggleButton selected;
+
+    public ModRadioButtonGroup(){
+        this.buttons = new ArrayList<ModToggleButton>();
+    }
+
+    public ModRadioButtonGroup(ModToggleButton... buttons){
+        for(ModToggleButton b : buttons){
+            addButton(b);
+        }
+    }
+
+    public boolean addButton(ModToggleButton b){
+        b.addConsumer(
+                button ->
+                {
+                    selectButton(button);
+                });
+        return buttons.add(b);
+    }
+
+    public boolean removeButton(ModToggleButton b){
+        return buttons.remove(b);
+    }
+
+    public void selectButton(ModToggleButton b){
+        this.selected=b;
+        updateButtons();
+    }
+
+    public void updateButtons(){
+        for(ModToggleButton b : buttons){
+            b.enabled = selected.equals(b);
+        }
+    }
+}

--- a/mod/src/main/java/basemod/ModToggleButton.java
+++ b/mod/src/main/java/basemod/ModToggleButton.java
@@ -11,7 +11,6 @@ import com.megacrit.cardcrawl.helpers.Hitbox;
 import com.megacrit.cardcrawl.helpers.ImageMaster;
 import com.megacrit.cardcrawl.helpers.input.InputHelper;
 
-import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;

--- a/mod/src/main/java/basemod/ModToggleButton.java
+++ b/mod/src/main/java/basemod/ModToggleButton.java
@@ -11,13 +11,17 @@ import com.megacrit.cardcrawl.helpers.Hitbox;
 import com.megacrit.cardcrawl.helpers.ImageMaster;
 import com.megacrit.cardcrawl.helpers.input.InputHelper;
 
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Consumer;
 
 public class ModToggleButton implements IUIElement {
 	private static final float TOGGLE_Y_DELTA = 0f;
 	private static final float TOGGLE_X_EXTEND = 12.0f;
 	private static final float HB_WIDTH_EXTENDED = 200.0f;
-	
+
+	private List<Consumer<ModToggleButton>> consumers = new ArrayList<Consumer<ModToggleButton>>();
 	private Consumer<ModToggleButton> toggle;
 	Hitbox hb;
 	private float x;
@@ -97,6 +101,9 @@ public class ModToggleButton implements IUIElement {
 	private void onToggle() {
 		this.enabled = !enabled;
 		toggle.accept(this);
+		for(Consumer<ModToggleButton> c : consumers){
+			c.accept(this);
+		}
 	}
 
 	public void toggle() {
@@ -143,5 +150,9 @@ public class ModToggleButton implements IUIElement {
 	@Override
 	public float getY() {
 		return y/Settings.scale;
+	}
+
+	public void addConsumer(Consumer<ModToggleButton> c){
+		consumers.add(c);
 	}
 }


### PR DESCRIPTION
Adds a RadioButtonGroup for use in ModConfigPages. To be used with ModToggleButtons.
Example Code
`ModToggleButton tb1 = new ...
ModToggleButton tb2 = new ...
ModLabeledToggleButton ltb1 = new ...
ModRadioButtonGroup radioButtons = new ModRadioButtonGroup(tb1,tb2,ltb1.toggle);
...
ModLabeledToggleButton ltb2 = new ...
radioButtons.addButton(ltb2.toggle);`

I would like to add the already existing Consumer `toggle` in ModToggleButton to the List of Consumers to avoid
`toggle.accept(this);
for(Consumer<ModToggleButton> c : consumers){
	c.accept(this);
}`
 But i am not sure if it would break any mods.