### PR TITLE
Add a hook for CustomPlayer to overwrite behavior when an enemy applies negative buff

### DIFF
--- a/mod/src/main/java/basemod/abstracts/CustomPlayer.java
+++ b/mod/src/main/java/basemod/abstracts/CustomPlayer.java
@@ -25,6 +25,7 @@ import com.megacrit.cardcrawl.helpers.ImageMaster;
 import com.megacrit.cardcrawl.helpers.Prefs;
 import com.megacrit.cardcrawl.helpers.SaveHelper;
 import com.megacrit.cardcrawl.localization.CharacterStrings;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.saveAndContinue.SaveAndContinue;
 import com.megacrit.cardcrawl.screens.CharSelectInfo;
 import com.megacrit.cardcrawl.screens.stats.CharStat;
@@ -345,5 +346,9 @@ public abstract class CustomPlayer extends AbstractPlayer implements ModelRender
 	public String getPortraitImageName()
 	{
 		return BaseMod.getPlayerPortrait(chosenClass);
+	}
+
+	public boolean onEnemyApplyNegativeBuff(AbstractMonster source, String powerId, int amount) {
+		return false;
 	}
 }

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/actions/common/ApplyPowerAction/EnemyApplyNegativeBuff.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/actions/common/ApplyPowerAction/EnemyApplyNegativeBuff.java
@@ -1,0 +1,44 @@
+package basemod.patches.com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+
+import basemod.abstracts.CustomPlayer;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePrefixPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpireReturn;
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+import com.megacrit.cardcrawl.powers.DexterityPower;
+import com.megacrit.cardcrawl.powers.FocusPower;
+import com.megacrit.cardcrawl.powers.StrengthPower;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+@SpirePatch(
+        clz = ApplyPowerAction.class,
+        paramtypez = {AbstractCreature.class, AbstractCreature.class, AbstractPower.class, int.class, boolean.class, AbstractGameAction.AttackEffect.class },
+        method=SpirePatch.CONSTRUCTOR)
+public class EnemyApplyNegativeBuff {
+    private static final Set<String> powerIds = new HashSet<>(Arrays.asList(StrengthPower.POWER_ID, DexterityPower.POWER_ID, FocusPower.POWER_ID));
+
+    @SpirePrefixPatch
+    public static SpireReturn<Void> prefix(ApplyPowerAction instance, AbstractCreature target, AbstractCreature source, AbstractPower powerToApply, int stackAmount) {
+        if (target instanceof CustomPlayer &&
+                source instanceof AbstractMonster &&
+                powerToApply != null &&
+                powerIds.contains(powerToApply.ID) &&
+                stackAmount < 0 &&
+                powerToApply.amount == stackAmount) {
+
+            if (((CustomPlayer) target).onEnemyApplyNegativeBuff((AbstractMonster) source, powerToApply.ID, stackAmount)) {
+                instance.isDone = true;
+                return SpireReturn.Return();
+            }
+        }
+
+        return SpireReturn.Continue();
+    }
+}


### PR DESCRIPTION
Monsters like Lagavulin or Spire Shield can apply negative buff to player. But for some mod characters, strength or dexterity doesn't make them powerful. This makes the specific monster action useless and weakens the monster.
This hook makes it possible for mod makers to overwrite the power to be applied to player by these monsters, just like Spire Shield can apply negative focus in some cases. But they can use their own power.