### PR TITLE
No fading limbo when clearing card queue

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/actions/GameActionManager/NoFadeLimbo.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/actions/GameActionManager/NoFadeLimbo.java
@@ -1,5 +1,6 @@
 package basemod.patches.com.megacrit.cardcrawl.actions.GameActionManager;
 
+import basemod.BaseMod;
 import com.evacipated.cardcrawl.modthespire.lib.*;
 import com.evacipated.cardcrawl.modthespire.patcher.PatchingException;
 import com.megacrit.cardcrawl.actions.GameActionManager;
@@ -16,7 +17,9 @@ public class NoFadeLimbo {
             locator = Locator.class
     )
     public static SpireReturn<Void> youCanStillRemoveTheCardsInHandThough(GameActionManager __instance) {
-        return SpireReturn.Return();
+        if (BaseMod.fixesEnabled)
+            return SpireReturn.Return();
+        return SpireReturn.Continue();
     }
 
     private static class Locator extends SpireInsertLocator

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/actions/GameActionManager/NoFadeLimbo.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/actions/GameActionManager/NoFadeLimbo.java
@@ -1,0 +1,31 @@
+package basemod.patches.com.megacrit.cardcrawl.actions.GameActionManager;
+
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.evacipated.cardcrawl.modthespire.patcher.PatchingException;
+import com.megacrit.cardcrawl.actions.GameActionManager;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import javassist.CannotCompileException;
+import javassist.CtBehavior;
+
+@SpirePatch(
+        clz = GameActionManager.class,
+        method = "cleanCardQueue"
+)
+public class NoFadeLimbo {
+    @SpireInsertPatch(
+            locator = Locator.class
+    )
+    public static SpireReturn<Void> youCanStillRemoveTheCardsInHandThough(GameActionManager __instance) {
+        return SpireReturn.Return();
+    }
+
+    private static class Locator extends SpireInsertLocator
+    {
+        public int[] Locate(CtBehavior ctMethodToPatch) throws CannotCompileException, PatchingException
+        {
+            Matcher finalMatcher = new Matcher.FieldAccessMatcher(AbstractPlayer.class, "limbo");
+
+            return LineFinder.findInOrder(ctMethodToPatch, finalMatcher);
+        }
+    }
+}


### PR DESCRIPTION
Changing this for a few reasons; this is only used when HandCardSelectScreen is opened, and doesn't actually *remove* any cards from limbo, just fade them out. In addition, the cards aren't even actually faded until after the HandCardSelectScreen closes, because they aren't updated before then. So the only result is making the cards in limbo invisible as or after they play.