### PR TITLE
Make custom card frames work with card descriptors

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderCardDescriptors.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderCardDescriptors.java
@@ -1,7 +1,9 @@
 package basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard;
 
+import basemod.ReflectionHacks;
 import basemod.abstracts.CustomCard;
 import basemod.helpers.CardModifierManager;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.GlyphLayout;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
@@ -12,6 +14,8 @@ import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.helpers.FontHelper;
 import javassist.CtBehavior;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -60,7 +64,7 @@ public class RenderCardDescriptors
 				locator = Locator.class,
 				localvars = {"tOffset", "tWidth"}
 		)
-		public static void Insert(AbstractCard __instance, SpriteBatch sb, float x, float y, @ByRef float[] tOffset, @ByRef float[] tWidth)
+		public static SpireReturn<Void> Insert(AbstractCard __instance, SpriteBatch sb, float x, float y, @ByRef float[] tOffset, @ByRef float[] tWidth)
 		{
 			String typeText;
 			switch (__instance.type) {
@@ -94,6 +98,25 @@ public class RenderCardDescriptors
 				tOffset[0] = (gl.width - 38 * Settings.scale) / 2f;
 				tWidth[0] = (gl.width - 0f) / (32 * Settings.scale);
 			}
+
+			if (__instance instanceof CustomCard) {
+				CustomCard card = (CustomCard) __instance;
+
+				if (card.frameSmallRegion != null) // Does it have a custom frame?
+				{
+					Color renderColor = ReflectionHacks.getPrivate(__instance, AbstractCard.class, "renderColor");
+					// I have to do it like this otherwise the game literally won't start
+					renderHelper(card, sb, renderColor, card.frameSmallRegion, x, y);
+
+					if (((CustomCard) __instance).frameMiddleRegion != null) { // Does it have custom dynamic frame parts?
+						dynamicFrameRenderHelper(sb, card.frameMiddleRegion, x, y, 0.0F, __instance.drawScale, __instance.angle, tWidth[0]);
+						dynamicFrameRenderHelper(sb, card.frameLeftRegion, x, y, -tOffset[0], __instance.drawScale, __instance.angle, 1.0F);
+						dynamicFrameRenderHelper(sb, card.frameRightRegion, x, y, tOffset[0], __instance.drawScale, __instance.angle, 1.0F);
+						return SpireReturn.Return();
+					}
+				}
+			}
+			return SpireReturn.Continue();
 		}
 
 		private static class Locator extends SpireInsertLocator
@@ -151,5 +174,43 @@ public class RenderCardDescriptors
 		}
 		list.addAll(CardModifierManager.getExtraDescriptors(card));
 		return list;
+	}
+
+	//renderHelper usability
+	private static Method renderHelperMethod;
+
+	static
+	{
+		try
+		{
+			renderHelperMethod = AbstractCard.class.getDeclaredMethod("renderHelper", SpriteBatch.class, Color.class, TextureAtlas.AtlasRegion.class, float.class, float.class);
+			renderHelperMethod.setAccessible(true);
+		} catch (NoSuchMethodException e) {
+			e.printStackTrace();
+		}
+	}
+
+	private static void renderHelper(AbstractCard card, SpriteBatch sb, Color color, TextureAtlas.AtlasRegion region, float xPos, float yPos)
+	{
+		try {
+			// use reflection hacks to invoke renderHelper (without float scale)
+			renderHelperMethod.invoke(card, sb, color, region, xPos, yPos);
+		} catch (IllegalAccessException | IllegalArgumentException | SecurityException | InvocationTargetException e) {
+			e.printStackTrace();
+		}
+	}
+
+	private static void dynamicFrameRenderHelper(SpriteBatch sb, TextureAtlas.AtlasRegion img, float x, float y, float xOffset, float drawScale, float angle, float xScale) {
+		sb.draw(img,
+				x + img.offsetX - (img.originalWidth / 2f) + xOffset * drawScale,
+				y + img.offsetY - img.originalHeight / 2f,
+				img.originalWidth / 2f - img.offsetX + 1,
+				img.originalHeight / 2f - img.offsetY,
+				img.packedWidth,
+				img.packedHeight,
+				Settings.scale * drawScale * xScale,
+				Settings.scale * drawScale,
+				angle
+		);
 	}
 }

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderCardDescriptors.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderCardDescriptors.java
@@ -104,8 +104,7 @@ public class RenderCardDescriptors
 
 				if (card.frameSmallRegion != null) // Does it have a custom frame?
 				{
-					Color renderColor = ReflectionHacks.getPrivate(__instance, AbstractCard.class, "renderColor");
-					// I have to do it like this otherwise the game literally won't start
+					Color renderColor = ReflectionHacks.getPrivate(__instance, AbstractCard.class, "renderColor"); // I have to do it like this otherwise the game literally won't start
 					renderHelper(card, sb, renderColor, card.frameSmallRegion, x, y);
 
 					if (((CustomCard) __instance).frameMiddleRegion != null) { // Does it have custom dynamic frame parts?
@@ -201,9 +200,14 @@ public class RenderCardDescriptors
 	}
 
 	private static void dynamicFrameRenderHelper(SpriteBatch sb, TextureAtlas.AtlasRegion img, float x, float y, float xOffset, float drawScale, float angle, float xScale) {
-		sb.draw(img,
-				x + img.offsetX - (img.originalWidth / 2f) + xOffset * drawScale,
-				y + img.offsetY - img.originalHeight / 2f,
+		Vector2 tmp = new Vector2(0,0);
+		tmp.set(xOffset, 0);
+		tmp.scl(drawScale);
+		tmp.rotate(angle);
+		sb.draw(
+				img,
+				x + img.offsetX - (img.originalWidth / 2f + 1) + tmp.x,
+				y + img.offsetY - img.originalHeight / 2f + tmp.y,
 				img.originalWidth / 2f - img.offsetX + 1,
 				img.originalHeight / 2f - img.offsetY,
 				img.packedWidth,

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderFixSwitches.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderFixSwitches.java
@@ -2,7 +2,6 @@ package basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard;
 
 import basemod.BaseMod;
 import basemod.abstracts.CustomCard;
-import basemod.helpers.SuperclassFinder;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -23,9 +22,10 @@ import javassist.expr.MethodCall;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+
+import static basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard.RenderCardDescriptors.getAllDescriptors;
 
 public class RenderFixSwitches
 {
@@ -64,6 +64,11 @@ public class RenderFixSwitches
 		{
 			//If it's not a CustomCard, no custom rendering
 			if (!(__instance instanceof CustomCard)) {
+				return SpireReturn.Continue();
+			}
+
+			// If the card has card descriptors, don't render here because the descriptor rendering will break
+			if (!getAllDescriptors(__instance).isEmpty()) {
 				return SpireReturn.Continue();
 			}
 

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/CustomRendering.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/CustomRendering.java
@@ -1,7 +1,6 @@
 package basemod.patches.com.megacrit.cardcrawl.screens.SingleCardViewPopup;
 
 import basemod.abstracts.CustomCard;
-import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
@@ -10,6 +9,8 @@ import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.helpers.ImageMaster;
 import com.megacrit.cardcrawl.screens.SingleCardViewPopup;
+
+import static basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard.RenderCardDescriptors.getAllDescriptors;
 
 public class CustomRendering {
     @SpirePatch(
@@ -46,6 +47,11 @@ public class CustomRendering {
         {
             //If it's not a CustomCard, no custom rendering
             if (!(___card instanceof CustomCard)) {
+                return SpireReturn.Continue();
+            }
+
+            // If the card has card descriptors, don't render here because the descriptor rendering will break
+            if (!getAllDescriptors(___card).isEmpty()) {
                 return SpireReturn.Continue();
             }
 

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderCardDescriptorsSCV.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderCardDescriptorsSCV.java
@@ -53,7 +53,7 @@ public class RenderCardDescriptorsSCV
 				locator = Locator.class,
 				localvars = {"tOffset", "tWidth"}
 		)
-		public static void Insert(SingleCardViewPopup __instance, SpriteBatch sb, AbstractCard ___card, @ByRef float[] tOffset, @ByRef float[] tWidth)
+		public static SpireReturn<Void> Insert(SingleCardViewPopup __instance, SpriteBatch sb, AbstractCard ___card, @ByRef float[] tOffset, @ByRef float[] tWidth)
 		{
 			//RenderCardDescriptors.Frame.Insert(___card, sb, 0, 0, tOffset, tWidth);
 			String typeText;
@@ -88,6 +88,24 @@ public class RenderCardDescriptorsSCV
 				tOffset[0] = (gl.width - 70 * Settings.scale) / 2f;
 				tWidth[0] = (gl.width - 0f) / (62 * Settings.scale);
 			}
+
+			if (___card instanceof CustomCard) {
+				CustomCard card = (CustomCard) ___card;
+
+				if (card.frameLargeRegion != null) // Does it have a custom frame?
+				{
+					renderHelper(sb, (float) Settings.WIDTH / 2.0F, (float) Settings.HEIGHT / 2.0F, ((CustomCard) ___card).frameLargeRegion);
+
+					if (card.frameMiddleLargeRegion != null) // Does it have custom dynamic frame parts?
+					{
+						dynamicFrameRenderHelper(sb, card.frameMiddleLargeRegion, 0.0F, tWidth[0]);
+						dynamicFrameRenderHelper(sb, card.frameLeftLargeRegion, -tOffset[0], 1.0F);
+						dynamicFrameRenderHelper(sb, card.frameRightLargeRegion, tOffset[0], 1.0F);
+						return SpireReturn.Return();
+					}
+				}
+			}
+			return SpireReturn.Continue();
 		}
 
 		private static class Locator extends SpireInsertLocator
@@ -132,5 +150,27 @@ public class RenderCardDescriptorsSCV
 			);
 			return SpireReturn.Return(null);
 		}
+	}
+
+	private static void renderHelper(SpriteBatch sb, float x, float y, TextureAtlas.AtlasRegion img) {
+		if (img != null)
+			sb.draw(img, x + img.offsetX - (float)img.originalWidth / 2.0F, y + img.offsetY - (float)img.originalHeight / 2.0F, (float)img.originalWidth / 2.0F - img.offsetX, (float)img.originalHeight / 2.0F - img.offsetY, (float)img.packedWidth, (float)img.packedHeight, Settings.scale, Settings.scale, 0.0F);
+	}
+
+	private static void dynamicFrameRenderHelper(SpriteBatch sb, TextureAtlas.AtlasRegion img, float xOffset, float xScale) {
+		Vector2 tmp = new Vector2(0, 0);
+		tmp.set(xOffset, 0);
+		sb.draw(
+				img,
+				Settings.WIDTH / 2f + img.offsetX - (img.originalWidth / 2f + 2) + tmp.x,
+				Settings.HEIGHT / 2f + img.offsetY - img.originalHeight / 2f + tmp.y,
+				img.originalWidth / 2f - img.offsetX + 2,
+				img.originalHeight / 2f - img.offsetY,
+				img.packedWidth,
+				img.packedHeight,
+				Settings.scale * xScale,
+				Settings.scale,
+				0f
+		);
 	}
 }


### PR DESCRIPTION
Card descriptors now render properly on cards which utilise "setPortraitTextures" and "setDisplayRarity"
Previously, the dynamic portrait frame would not update to the correct size when using a custom frame texture or rarity
![image](https://github.com/daviscook477/BaseMod/assets/85409980/454e5665-a4ba-4970-8333-41b37bc39357)
e.g. this card is actually COMMON but the descriptor box updates to the correct size and matches its RARE display rarity