### PR TITLE
adding pagination to shop 2x3 grid to allow for more items

### DIFF
--- a/mod/src/main/java/basemod/BaseMod.java
+++ b/mod/src/main/java/basemod/BaseMod.java
@@ -11,6 +11,7 @@ import basemod.interfaces.*;
 import basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard.RenderDescriptionEnergy;
 import basemod.patches.com.megacrit.cardcrawl.helpers.TopPanel.TopPanelHelper;
 import basemod.patches.com.megacrit.cardcrawl.screens.select.GridCardSelectScreen.GridCardSelectScreenFields;
+import basemod.patches.com.megacrit.cardcrawl.shop.ShopScreen.ShopItemGrid;
 import basemod.patches.com.megacrit.cardcrawl.unlock.UnlockTracker.CountModdedUnlockCards;
 import basemod.patches.imgui.ImGuiPatches;
 import basemod.patches.whatmod.WhatMod;
@@ -120,6 +121,7 @@ public class BaseMod {
 	private static ArrayList<PostDungeonInitializeSubscriber> postDungeonInitializeSubscribers;
 	private static ArrayList<PostEnergyRechargeSubscriber> postEnergyRechargeSubscribers;
 	private static ArrayList<PostInitializeSubscriber> postInitializeSubscribers;
+	private static ArrayList<PostShopInitializeSubscriber> postShopInitializeSubscribers;
 	private static ArrayList<PreMonsterTurnSubscriber> preMonsterTurnSubscribers;
 	private static ArrayList<RenderSubscriber> renderSubscribers;
 	private static ArrayList<PreRenderSubscriber> preRenderSubscribers;
@@ -461,6 +463,7 @@ public class BaseMod {
 		postDungeonInitializeSubscribers = new ArrayList<>();
 		postEnergyRechargeSubscribers = new ArrayList<>();
 		postInitializeSubscribers = new ArrayList<>();
+		postShopInitializeSubscribers = new ArrayList<>();
 		preMonsterTurnSubscribers = new ArrayList<>();
 		renderSubscribers = new ArrayList<>();
 		preRenderSubscribers = new ArrayList<>();
@@ -2302,6 +2305,17 @@ public class BaseMod {
 		unsubscribeLaterHelper(PostInitializeSubscriber.class);
 	}
 
+	// publishPostShopInitialize -
+	public static void publishPostShopInitialize() {
+		logger.info("publishPostShopInitialize");
+
+		for (PostShopInitializeSubscriber sub : postShopInitializeSubscribers) {
+			sub.receivePostShopInitialize();
+		}
+
+		unsubscribeLaterHelper(PostShopInitializeSubscriber.class);
+	}
+
 	// publishPreMonsterTurn - false skips monster turn
 	public static boolean publishPreMonsterTurn(AbstractMonster m) {
 		logger.info("publishPreMonsterTurn");
@@ -2862,6 +2876,7 @@ public class BaseMod {
 		subscribeIfInstance(postDungeonInitializeSubscribers, sub, PostDungeonInitializeSubscriber.class);
 		subscribeIfInstance(postEnergyRechargeSubscribers, sub, PostEnergyRechargeSubscriber.class);
 		subscribeIfInstance(postInitializeSubscribers, sub, PostInitializeSubscriber.class);
+		subscribeIfInstance(postShopInitializeSubscribers, sub, PostShopInitializeSubscriber.class);
 		subscribeIfInstance(preMonsterTurnSubscribers, sub, PreMonsterTurnSubscriber.class);
 		subscribeIfInstance(renderSubscribers, sub, RenderSubscriber.class);
 		subscribeIfInstance(preRenderSubscribers, sub, PreRenderSubscriber.class);
@@ -2925,6 +2940,8 @@ public class BaseMod {
 			postEnergyRechargeSubscribers.add((PostEnergyRechargeSubscriber) sub);
 		} else if (additionClass.equals(PostInitializeSubscriber.class)) {
 			postInitializeSubscribers.add((PostInitializeSubscriber) sub);
+		} else if (additionClass.equals(PostShopInitializeSubscriber.class)) {
+			postShopInitializeSubscribers.add((PostShopInitializeSubscriber) sub);
 		} else if (additionClass.equals(PreMonsterTurnSubscriber.class)) {
 			preMonsterTurnSubscribers.add((PreMonsterTurnSubscriber) sub);
 		} else if (additionClass.equals(RenderSubscriber.class)) {
@@ -3021,6 +3038,7 @@ public class BaseMod {
 		unsubscribeIfInstance(postDungeonInitializeSubscribers, sub, PostDungeonInitializeSubscriber.class);
 		unsubscribeIfInstance(postEnergyRechargeSubscribers, sub, PostEnergyRechargeSubscriber.class);
 		unsubscribeIfInstance(postInitializeSubscribers, sub, PostInitializeSubscriber.class);
+		unsubscribeIfInstance(postShopInitializeSubscribers, sub, PostShopInitializeSubscriber.class);
 		unsubscribeIfInstance(preMonsterTurnSubscribers, sub, PreMonsterTurnSubscriber.class);
 		unsubscribeIfInstance(renderSubscribers, sub, RenderSubscriber.class);
 		unsubscribeIfInstance(preRenderSubscribers, sub, PreRenderSubscriber.class);
@@ -3083,6 +3101,8 @@ public class BaseMod {
 			postEnergyRechargeSubscribers.remove(sub);
 		} else if (removalClass.equals(PostInitializeSubscriber.class)) {
 			postInitializeSubscribers.remove(sub);
+		} else if (removalClass.equals(PostInitializeSubscriber.class)) {
+			postShopInitializeSubscribers.remove(sub);
 		} else if (removalClass.equals(PreMonsterTurnSubscriber.class)) {
 			preMonsterTurnSubscribers.remove(sub);
 		} else if (removalClass.equals(RenderSubscriber.class)) {

--- a/mod/src/main/java/basemod/abstracts/CustomShopItem.java
+++ b/mod/src/main/java/basemod/abstracts/CustomShopItem.java
@@ -1,0 +1,151 @@
+package basemod.abstracts;
+
+import basemod.ReflectionHacks;
+import basemod.patches.com.megacrit.cardcrawl.shop.ShopScreen.ShopItemGrid;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.helpers.FontHelper;
+import com.megacrit.cardcrawl.helpers.Hitbox;
+import com.megacrit.cardcrawl.helpers.ImageMaster;
+import com.megacrit.cardcrawl.helpers.TipHelper;
+import com.megacrit.cardcrawl.helpers.controller.CInputActionSet;
+import com.megacrit.cardcrawl.helpers.input.InputHelper;
+import com.megacrit.cardcrawl.shop.ShopScreen;
+import com.megacrit.cardcrawl.shop.StorePotion;
+import com.megacrit.cardcrawl.shop.StoreRelic;
+
+public class CustomShopItem {
+
+    private ShopScreen screenRef;
+    private StoreRelic storeRelic;
+    private StorePotion storePotion;
+
+    private String tipTitle = null;
+    private String tipBody = null;
+
+    private Texture img;
+    private Hitbox hb;
+    private float x, y;
+
+    public int price = 0;
+    public int slot = 0;
+    public int row;
+
+    public boolean isPurchased = false;
+
+    private static final float GOLD_IMG_WIDTH = ReflectionHacks.getPrivateStatic(StoreRelic.class, "GOLD_IMG_WIDTH");
+    private static final float GOLD_OFFSET_X = ReflectionHacks.getPrivateStatic(StoreRelic.class, "RELIC_GOLD_OFFSET_X");
+    private static final float GOLD_OFFSET_Y = ReflectionHacks.getPrivateStatic(StoreRelic.class, "RELIC_GOLD_OFFSET_Y");
+    private static final float PRICE_OFFSET_X = ReflectionHacks.getPrivateStatic(StoreRelic.class, "RELIC_PRICE_OFFSET_X");
+    private static final float PRICE_OFFSET_Y = ReflectionHacks.getPrivateStatic(StoreRelic.class, "RELIC_PRICE_OFFSET_Y");
+
+    public CustomShopItem(StoreRelic storeRelic) {
+        this.storeRelic = storeRelic;
+        this.slot = ReflectionHacks.getPrivate(storeRelic, StoreRelic.class, "slot");
+    }
+
+    public CustomShopItem(StorePotion storePotion) {
+        this.storePotion = storePotion;
+        this.slot = ReflectionHacks.getPrivate(storePotion, StorePotion.class, "slot");
+    }
+
+    public CustomShopItem(ShopScreen screenRef, Texture img, int price) {
+        this.screenRef = screenRef;
+        this.img = img;
+        this.price = price;
+        this.hb = new Hitbox(img.getWidth() * Settings.scale, img.getHeight() * Settings.scale);
+    }
+
+    public CustomShopItem(ShopScreen screenRef, Texture img, int price, String tipTitle, String tipBody) {
+        this(screenRef, img, price);
+        this.tipTitle = tipTitle;
+        this.tipBody = tipBody;
+    }
+
+    public void update(float rugY) {
+        if (storeRelic != null && storeRelic.relic != null) {
+            storeRelic.update(rugY);
+            return;
+        } else if (storePotion != null && storePotion.potion != null) {
+            storePotion.update(rugY);
+            return;
+        } else if (!this.isPurchased) {
+            this.x = 1000.0F * Settings.xScale + 150.0F * this.slot * Settings.xScale;
+            this.y = rugY + (this.row == 0 ? 400.0F : 200.0F) * Settings.yScale;
+
+            this.hb.move(this.x, this.y);
+            this.hb.update();
+            if (this.hb.hovered) {
+                this.screenRef.moveHand(this.x - 190.0F * Settings.scale, this.y - 70.0F * Settings.scale);
+                if (InputHelper.justClickedLeft)
+                    this.hb.clickStarted = true;
+            }
+            if (this.hb.clicked || (this.hb.hovered && CInputActionSet.select.isJustPressed())) {
+                if (AbstractDungeon.player.gold >= this.price) {
+                    makePurchase();
+                    this.isPurchased = true;
+                    this.hb.clicked = false;
+                } else {
+                    this.screenRef.playCantBuySfx();
+                    this.screenRef.createSpeech(ShopScreen.getCantBuyMsg());
+                }
+            }
+        }
+    }
+
+    public void render(SpriteBatch sb) {
+        if (storeRelic != null && storeRelic.relic != null)
+            this.storeRelic.render(sb);
+        else if (storePotion != null && storePotion.potion != null)
+            this.storePotion.render(sb);
+        else if (!isPurchased) {
+            sb.setColor(Color.WHITE);
+            // assumes the size of a relic image
+            sb.draw(img, x - 64.0F, y - 64.0F, 64.0F, 64.0F, 128.0F, 128.0F, Settings.scale, Settings.scale, 0.0F, 0, 0, 128, 128, false, false);
+            sb.draw(ImageMaster.UI_GOLD, x + GOLD_OFFSET_X, y + GOLD_OFFSET_Y, GOLD_IMG_WIDTH, GOLD_IMG_WIDTH);
+            Color color = Color.WHITE;
+            if (this.price > AbstractDungeon.player.gold)
+                color = Color.SALMON;
+            FontHelper.renderFontLeftTopAligned(sb, FontHelper.tipHeaderFont, Integer.toString(this.price), x + PRICE_OFFSET_X, y + PRICE_OFFSET_Y, color);
+            if (this.hb.hovered && tipTitle != null && tipBody != null)
+                TipHelper.renderGenericTip(
+                    InputHelper.mX + 50.0F * Settings.xScale,
+                    InputHelper.mY + 50.0F * Settings.yScale,
+                    tipTitle,
+                    tipBody
+                );
+        }
+    }
+
+    public void hide() {
+        if (storeRelic != null && storeRelic.relic != null) {
+            this.storeRelic.hide();
+            this.y = storeRelic.relic.currentY;
+        }
+        else if (storePotion != null && storePotion.potion != null) {
+            this.storePotion.hide();
+            this.y = storePotion.potion.posY;
+        }
+        else {
+            this.y = Settings.HEIGHT + 200.0F * Settings.scale;
+        }
+    }
+
+    protected void makePurchase() {
+        if (storeRelic != null && storeRelic.relic != null) {
+            this.storeRelic.purchaseRelic();
+        } else if (storePotion != null && storePotion.potion != null) {
+            this.storePotion.purchasePotion();
+        } else {
+            purchase();
+        }
+        this.isPurchased = true;
+        ShopItemGrid.removeEmptyPages();
+    }
+
+    public void purchase() {}
+}

--- a/mod/src/main/java/basemod/abstracts/CustomShopItem.java
+++ b/mod/src/main/java/basemod/abstracts/CustomShopItem.java
@@ -2,10 +2,10 @@ package basemod.abstracts;
 
 import basemod.ReflectionHacks;
 import basemod.patches.com.megacrit.cardcrawl.shop.ShopScreen.ShopItemGrid;
-
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.helpers.FontHelper;
@@ -21,8 +21,8 @@ import com.megacrit.cardcrawl.shop.StoreRelic;
 public class CustomShopItem {
 
     private ShopScreen screenRef;
-    private StoreRelic storeRelic;
-    private StorePotion storePotion;
+    public StoreRelic storeRelic;
+    public StorePotion storePotion;
 
     private String tipTitle = null;
     private String tipBody = null;
@@ -54,6 +54,7 @@ public class CustomShopItem {
     }
 
     public CustomShopItem(ShopScreen screenRef, Texture img, int price) {
+        this.slot = ShopItemGrid.getNextSlot();
         this.screenRef = screenRef;
         this.img = img;
         this.hb = new Hitbox(img.getWidth() * Settings.scale, img.getHeight() * Settings.scale);
@@ -73,85 +74,107 @@ public class CustomShopItem {
     }
 
     public void update(float rugY) {
-        if (storeRelic != null && storeRelic.relic != null) {
-            storeRelic.update(rugY);
-            return;
-        } else if (storePotion != null && storePotion.potion != null) {
-            storePotion.update(rugY);
-            return;
-        } else if (!this.isPurchased) {
-            this.x = 1000.0F * Settings.xScale + 150.0F * this.slot * Settings.xScale;
-            this.y = rugY + (this.row == 0 ? 400.0F : 200.0F) * Settings.yScale;
+        if (!this.isPurchased) {
+            if (storeRelic != null && storeRelic.relic != null) {
+                storeRelic.update(rugY);
+                this.isPurchased = storeRelic.isPurchased;
+                if (this.isPurchased) {
+                    this.storeRelic.relic = null;
+                    this.storeRelic = null;
+                }
+            } else if (storePotion != null && storePotion.potion != null) {
+                storePotion.update(rugY);
+                this.isPurchased = storePotion.isPurchased;
+                if (this.isPurchased) {
+                    this.storePotion.potion = null;
+                    this.storePotion = null;
+                }
+            } else {
+                this.x = 1000.0F * Settings.xScale + 150.0F * this.slot * Settings.xScale;
+                this.y = rugY + (this.row == 0 ? 400.0F : 200.0F) * Settings.yScale;
 
-            this.hb.move(this.x, this.y);
-            this.hb.update();
-            if (this.hb.hovered) {
-                this.screenRef.moveHand(this.x - 190.0F * Settings.scale, this.y - 70.0F * Settings.scale);
-                if (InputHelper.justClickedLeft)
-                    this.hb.clickStarted = true;
-            }
-            if (this.hb.clicked || (this.hb.hovered && CInputActionSet.select.isJustPressed())) {
-                if (AbstractDungeon.player.gold >= this.price) {
-                    makePurchase();
+                this.hb.move(this.x, this.y);
+                this.hb.update();
+                if (this.hb.hovered) {
+                    this.screenRef.moveHand(this.x - 190.0F * Settings.scale, this.y - 70.0F * Settings.scale);
+                    if (InputHelper.justClickedLeft)
+                        this.hb.clickStarted = true;
+                }
+                if (this.hb.clicked || (this.hb.hovered && CInputActionSet.select.isJustPressed())) {
+                    attemptPurchase();
                     this.hb.clicked = false;
-                } else {
-                    this.screenRef.playCantBuySfx();
-                    this.screenRef.createSpeech(ShopScreen.getCantBuyMsg());
                 }
             }
+            ShopItemGrid.removeEmptyPages();
         }
     }
 
     public void render(SpriteBatch sb) {
-        if (storeRelic != null && storeRelic.relic != null)
-            this.storeRelic.render(sb);
-        else if (storePotion != null && storePotion.potion != null)
-            this.storePotion.render(sb);
-        else if (!isPurchased) {
-            sb.setColor(Color.WHITE);
-            // assumes the size of a relic image
-            sb.draw(img, x - 64.0F, y - 64.0F, 64.0F, 64.0F, 128.0F, 128.0F, Settings.scale, Settings.scale, 0.0F, 0, 0, 128, 128, false, false);
-            sb.draw(ImageMaster.UI_GOLD, x + GOLD_OFFSET_X, y + GOLD_OFFSET_Y, GOLD_IMG_WIDTH, GOLD_IMG_WIDTH);
-            Color color = Color.WHITE;
-            if (this.price > AbstractDungeon.player.gold)
-                color = Color.SALMON;
-            FontHelper.renderFontLeftTopAligned(sb, FontHelper.tipHeaderFont, Integer.toString(this.price), x + PRICE_OFFSET_X, y + PRICE_OFFSET_Y, color);
-            if (this.hb.hovered && tipTitle != null && tipBody != null)
-                TipHelper.renderGenericTip(
-                    InputHelper.mX + 50.0F * Settings.xScale,
-                    InputHelper.mY + 50.0F * Settings.yScale,
-                    tipTitle,
-                    tipBody
-                );
+        if (!this.isPurchased) {
+            if (storeRelic != null && storeRelic.relic != null)
+                this.storeRelic.render(sb);
+            else if (storePotion != null && storePotion.potion != null)
+                this.storePotion.render(sb);
+            else {
+                sb.setColor(Color.WHITE);
+                // assumes the size of a relic image
+                sb.draw(img, x - 64.0F, y - 64.0F, 64.0F, 64.0F, 128.0F, 128.0F, Settings.scale, Settings.scale, 0.0F, 0, 0, 128, 128, false, false);
+                sb.draw(ImageMaster.UI_GOLD, x + GOLD_OFFSET_X, y + GOLD_OFFSET_Y, GOLD_IMG_WIDTH, GOLD_IMG_WIDTH);
+                Color color = Color.WHITE;
+                if (this.price > AbstractDungeon.player.gold)
+                    color = Color.SALMON;
+                FontHelper.renderFontLeftTopAligned(sb, FontHelper.tipHeaderFont, Integer.toString(this.price), x + PRICE_OFFSET_X, y + PRICE_OFFSET_Y, color);
+                if (this.hb.hovered && tipTitle != null && tipBody != null)
+                    TipHelper.renderGenericTip(
+                        InputHelper.mX + 50.0F * Settings.xScale,
+                        InputHelper.mY + 50.0F * Settings.yScale,
+                        tipTitle,
+                        tipBody
+                    );
+            }
         }
     }
 
     public void hide() {
-        if (storeRelic != null && storeRelic.relic != null) {
-            this.storeRelic.hide();
-            this.y = storeRelic.relic.currentY;
-        }
-        else if (storePotion != null && storePotion.potion != null) {
-            this.storePotion.hide();
-            this.y = storePotion.potion.posY;
-        }
-        else {
-            this.y = Settings.HEIGHT + 200.0F * Settings.scale;
+        if (!this.isPurchased) {
+            if (storeRelic != null && storeRelic.relic != null) {
+                this.storeRelic.hide();
+                this.y = storeRelic.relic.currentY;
+            }
+            else if (storePotion != null && storePotion.potion != null) {
+                this.storePotion.hide();
+                this.y = storePotion.potion.posY;
+            }
+            else {
+                this.y = Settings.HEIGHT + 200.0F * Settings.scale;
+            }
         }
     }
 
-    protected void makePurchase() {
-        if (storeRelic != null && storeRelic.relic != null) {
-            this.storeRelic.purchaseRelic();
-        } else if (storePotion != null && storePotion.potion != null) {
-            this.storePotion.purchasePotion();
-        } else {
-            purchase();
+    protected void attemptPurchase() {
+        if (!this.isPurchased) {
+            if (storeRelic != null && storeRelic.relic != null) {
+                this.storeRelic.purchaseRelic();
+                this.storeRelic.relic = null;
+                this.storeRelic = null;
+                this.isPurchased = true;
+            } else if (storePotion != null && storePotion.potion != null) {
+                this.storePotion.purchasePotion();
+                this.storePotion.potion = null;
+                this.storePotion = null;
+                this.isPurchased = true;
+            } else if (AbstractDungeon.player.gold >= this.price){
+                purchase();
+            } else {
+                this.screenRef.playCantBuySfx();
+                this.screenRef.createSpeech(ShopScreen.getCantBuyMsg());
+            }
         }
-        ShopItemGrid.removeEmptyPages();
     }
 
     public void purchase() {
         this.isPurchased = true;
+        AbstractDungeon.player.loseGold(this.price);
+        CardCrawlGame.sound.play("SHOP_PURCHASE", 0.1F);
     }
 }

--- a/mod/src/main/java/basemod/abstracts/CustomShopItem.java
+++ b/mod/src/main/java/basemod/abstracts/CustomShopItem.java
@@ -56,14 +56,20 @@ public class CustomShopItem {
     public CustomShopItem(ShopScreen screenRef, Texture img, int price) {
         this.screenRef = screenRef;
         this.img = img;
-        this.price = price;
         this.hb = new Hitbox(img.getWidth() * Settings.scale, img.getHeight() * Settings.scale);
+        applyDiscounts(price);
     }
 
     public CustomShopItem(ShopScreen screenRef, Texture img, int price, String tipTitle, String tipBody) {
         this(screenRef, img, price);
         this.tipTitle = tipTitle;
         this.tipBody = tipBody;
+    }
+
+    public void applyDiscounts(int price) {
+        this.price = (int)(price
+            * (AbstractDungeon.player.hasRelic("The Courier") ? 0.8F : 1.0F)
+            * (AbstractDungeon.player.hasRelic("Membership Card") ? 0.5F : 1.0F));
     }
 
     public void update(float rugY) {
@@ -87,7 +93,6 @@ public class CustomShopItem {
             if (this.hb.clicked || (this.hb.hovered && CInputActionSet.select.isJustPressed())) {
                 if (AbstractDungeon.player.gold >= this.price) {
                     makePurchase();
-                    this.isPurchased = true;
                     this.hb.clicked = false;
                 } else {
                     this.screenRef.playCantBuySfx();
@@ -143,9 +148,10 @@ public class CustomShopItem {
         } else {
             purchase();
         }
-        this.isPurchased = true;
         ShopItemGrid.removeEmptyPages();
     }
 
-    public void purchase() {}
+    public void purchase() {
+        this.isPurchased = true;
+    }
 }

--- a/mod/src/main/java/basemod/interfaces/PostShopInitializeSubscriber.java
+++ b/mod/src/main/java/basemod/interfaces/PostShopInitializeSubscriber.java
@@ -1,0 +1,5 @@
+package basemod.interfaces;
+
+public interface PostShopInitializeSubscriber extends ISubscriber {
+    void receivePostShopInitialize();
+}

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/shop/ShopScreen/ShopItemGrid.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/shop/ShopScreen/ShopItemGrid.java
@@ -1,0 +1,364 @@
+package basemod.patches.com.megacrit.cardcrawl.shop.ShopScreen;
+
+import basemod.BaseMod;
+import basemod.ReflectionHacks;
+import basemod.abstracts.CustomShopItem;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.evacipated.cardcrawl.modthespire.lib.LineFinder;
+import com.evacipated.cardcrawl.modthespire.lib.Matcher;
+import com.evacipated.cardcrawl.modthespire.lib.SpireInsertLocator;
+import com.evacipated.cardcrawl.modthespire.lib.SpireInsertPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpireInstrumentPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch2;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.helpers.FontHelper;
+import com.megacrit.cardcrawl.helpers.Hitbox;
+import com.megacrit.cardcrawl.helpers.ImageMaster;
+import com.megacrit.cardcrawl.helpers.controller.CInputActionSet;
+import com.megacrit.cardcrawl.helpers.input.InputHelper;
+import com.megacrit.cardcrawl.shop.ShopScreen;
+import com.megacrit.cardcrawl.shop.StorePotion;
+import com.megacrit.cardcrawl.shop.StoreRelic;
+import java.util.ArrayList;
+import java.util.LinkedList;
+
+import javassist.CannotCompileException;
+import javassist.CtBehavior;
+import javassist.expr.ExprEditor;
+import javassist.expr.MethodCall;
+
+public class ShopItemGrid {
+    public static LinkedList<ShopItemPage> pages = new LinkedList<>();
+    public static ShopItemPage currentPage;
+    public static NavButton leftArrow;
+    public static NavButton rightArrow;
+    private static float pageIdxY;
+
+    @SpirePatch2(
+        clz = ShopScreen.class,
+        method = "init"
+    )
+    public static class InitPage {
+        @SpirePostfixPatch
+        public static void Postfix() {
+            BaseMod.publishPostShopInitialize();
+        }
+
+        @SpireInsertPatch(
+            locator = Locator.class
+        )
+        public static void Insert(ArrayList<StoreRelic> ___relics, ArrayList<StorePotion> ___potions) {
+            ShopItemPage page = new ShopItemPage();
+            page.row1 = ShopItemRow.makeDefaultRelicRow(___relics, 0);
+            page.row2 = ShopItemRow.makeDefaultPotionRow(___potions, 1);
+            pages.clear();
+            pages.addLast(page);
+            currentPage = page;
+            rightArrow = new NavButton(true);
+            leftArrow = new NavButton(false);
+        }
+
+        private static class Locator extends SpireInsertLocator {
+            @Override
+            public int[] Locate(CtBehavior ctb) throws Exception {
+                Matcher finalMatcher = new Matcher.FieldAccessMatcher(ShopScreen.class, "purgeAvailable");
+                return LineFinder.findInOrder(ctb, new ArrayList<Matcher>(), finalMatcher);
+            }
+        }
+    }
+
+    @SpirePatch2(
+        clz = ShopScreen.class,
+        method = "open"
+    )
+    public static class HideOnOpen {
+        @SpireInsertPatch(
+            locator = Locator.class
+        )
+        public static void Insert() {
+            currentPage.hide();
+            leftArrow.hide();
+            rightArrow.hide();
+        }
+
+        private static class Locator extends SpireInsertLocator {
+            @Override
+            public int[] Locate(CtBehavior ctb) throws Exception {
+                Matcher finalMatcher = new Matcher.FieldAccessMatcher(ShopScreen.class, "rugY");
+                return LineFinder.findInOrder(ctb, new ArrayList<Matcher>(), finalMatcher);
+            }
+        }
+    }
+
+    @SpirePatch2(
+        clz = ShopScreen.class,
+        method = "update"
+    )
+    public static class UpdateCurrentPage {
+        @SpireInstrumentPatch
+        public static ExprEditor Instrument() {
+            return new ExprEditor() {
+                public void edit(MethodCall m) throws CannotCompileException {
+                    if (m.getMethodName().equals("updateRelics") || m.getMethodName().equals("updatePotions"))
+                        m.replace("{}");
+                }
+            };
+        }
+
+        @SpireInsertPatch(
+            locator = Locator.class
+        )
+        public static void Insert(float ___rugY) {
+            currentPage.update(___rugY);
+        }
+
+        private static class Locator extends SpireInsertLocator {
+            @Override
+            public int[] Locate(CtBehavior ctb) throws Exception {
+                Matcher finalMatcher = new Matcher.MethodCallMatcher(ShopScreen.class, "updateRug");
+                return LineFinder.findInOrder(ctb, new ArrayList<Matcher>(), finalMatcher);
+            }
+        }
+    }
+
+    @SpirePatch2(
+        clz = ShopScreen.class,
+        method = "render"
+    )
+    public static class RenderCurrentPage {
+        @SpireInstrumentPatch
+        public static ExprEditor Instrument() {
+            return new ExprEditor() {
+                public void edit(MethodCall m) throws CannotCompileException {
+                    if (m.getMethodName().equals("renderRelics") || m.getMethodName().equals("renderPotions"))
+                        m.replace("{}");
+                }
+            };
+        }
+
+        @SpireInsertPatch(
+            locator = Locator.class
+        )
+        public static void Insert(SpriteBatch sb) {
+            currentPage.render(sb);
+        }
+
+        private static class Locator extends SpireInsertLocator {
+            @Override
+            public int[] Locate(CtBehavior ctb) throws Exception {
+                Matcher finalMatcher = new Matcher.MethodCallMatcher(ShopScreen.class, "renderPurge");
+                return LineFinder.findInOrder(ctb, new ArrayList<Matcher>(), finalMatcher);
+            }
+        }
+    }
+
+    public static void addItem(CustomShopItem item) {
+        if (currentPage != null && currentPage.tryAddItem(item))
+            return;
+        ShopItemPage newPage = new ShopItemPage();
+        newPage.tryAddItem(item);
+        pages.addLast(newPage);
+        if (currentPage == null)
+            currentPage = newPage;
+    }
+
+    public static void removeEmptyPages() {
+        ShopItemPage page = currentPage;
+        if (page.isEmpty()) {
+            int newIdx = pages.indexOf(page) - 1;
+            pages.remove(page);
+            currentPage = (newIdx == -1 ? null : pages.get(newIdx));
+        }
+    }
+
+    public static class ShopItemPage {
+        public ShopItemRow row1;
+        public ShopItemRow row2;
+
+        public ShopItemPage() {
+            this.row1 = new ShopItemRow(0);
+            this.row2 = new ShopItemRow(1);
+        }
+
+        public void hide() {
+            row1.hide();
+            row2.hide();
+        }
+
+        public void update(float rugY) {
+            row1.update(rugY);
+            row2.update(rugY);
+            leftArrow.update(rugY);
+            rightArrow.update(rugY);
+            pageIdxY = rugY + 500.0F * Settings.yScale;
+        }
+
+        public void render(SpriteBatch sb) {
+            row1.render(sb);
+            row2.render(sb);
+            leftArrow.render(sb);
+            rightArrow.render(sb);
+            if (pages.size() > 1)
+                FontHelper.renderFontCentered(
+                    sb,
+                    FontHelper.buttonLabelFont,
+                    (pages.indexOf(currentPage) + 1) + "/" + pages.size(),
+                    1150.0F * Settings.xScale,
+                    pageIdxY,
+                    Color.WHITE
+                );
+        }
+
+        public boolean tryAddItem(CustomShopItem item) {
+            return row1.tryAddItem(item) || row2.tryAddItem(item);
+        }
+
+        public boolean isEmpty() {
+            return row1.isEmpty() && row2.isEmpty();
+        }
+    }
+
+    public static class ShopItemRow {
+        public static final int MAX_ITEMS_PER_ROW = 3;
+
+        public ArrayList<CustomShopItem> items;
+        public int row;
+
+        private boolean isDefaultRelics = false;
+        private boolean isDefaultPotions = false;
+
+        public ShopItemRow(int row) {
+            this.items = new ArrayList<>();
+            this.row = row;
+        }
+
+        public static ShopItemRow makeDefaultRelicRow(ArrayList<StoreRelic> relics, int row) {
+            ShopItemRow itemRow = new ShopItemRow(row);
+            itemRow.items = new ArrayList<>();
+            itemRow.row = row;
+            itemRow.isDefaultRelics = true;
+            for (StoreRelic relic : relics) {
+                itemRow.items.add(new CustomShopItem(relic));
+            }
+            return itemRow;
+        }
+
+        public static ShopItemRow makeDefaultPotionRow(ArrayList<StorePotion> potions, int row) {
+            ShopItemRow itemRow = new ShopItemRow(row);
+            itemRow.items = new ArrayList<>();
+            itemRow.row = row;
+            itemRow.isDefaultPotions = true;
+            for (StorePotion potion : potions) {
+                itemRow.items.add(new CustomShopItem(potion));
+            }
+            return itemRow;
+        }
+
+        public boolean tryAddItem(CustomShopItem item) {
+            if (items.size() < MAX_ITEMS_PER_ROW) {
+                item.row = this.row;
+                item.slot = items.size();
+                items.add(item);
+                return true;
+            }
+            return false;
+        }
+
+        public void update(float rugY) {
+            if (isDefaultRelics) {
+                ReflectionHacks.privateMethod(ShopScreen.class, "updateRelics").invoke(AbstractDungeon.shopScreen);
+                return;
+            }
+            if (isDefaultPotions) {
+                ReflectionHacks.privateMethod(ShopScreen.class, "updatePotions").invoke(AbstractDungeon.shopScreen);
+                return;
+            }
+            for (CustomShopItem item : items) {
+                item.update(rugY);
+            }
+        }
+
+        public void render(SpriteBatch sb) {
+            if (isDefaultRelics && AbstractDungeon.shopScreen != null) {
+                ReflectionHacks.privateMethod(ShopScreen.class, "renderRelics", SpriteBatch.class).invoke(AbstractDungeon.shopScreen, sb);
+                return;
+            }
+            if (isDefaultPotions && AbstractDungeon.shopScreen != null) {
+                ReflectionHacks.privateMethod(ShopScreen.class, "renderPotions", SpriteBatch.class).invoke(AbstractDungeon.shopScreen, sb);
+                return;
+            }
+            if (AbstractDungeon.shopScreen != null)
+                for (CustomShopItem item : items) {
+                    item.render(sb);
+                }
+        }
+
+        public void hide() {
+            for (CustomShopItem item : items) {
+                item.hide();
+            }
+        }
+
+        public boolean isEmpty() {
+            BaseMod.logger.info("Checking if row is empty: " + items.size());
+            BaseMod.logger.info("Checking if row is empty: " + items.stream().filter(item -> !item.isPurchased).count());
+            return (items.stream().filter(item -> !item.isPurchased).count() == 0);
+        }
+    }
+
+    public static class NavButton {
+        public static Texture texture = ImageMaster.POPUP_ARROW;
+        public Hitbox hb;
+
+        private float x, y;
+
+        public boolean forward = true;
+
+        public NavButton(boolean forward) {
+            this.forward = forward;
+            this.hb = new Hitbox(64.0F * Settings.scale, 64.0F * Settings.scale);
+        }
+
+        public void update(float rugY) {
+            this.x = (forward ? 1225.0F : 1075.0F) * Settings.xScale;
+            this.y = rugY + 500.0F * Settings.yScale;
+            this.hb.move(x, y);
+            this.hb.update();
+            if (this.hb.hovered && InputHelper.justClickedLeft)
+                hb.clickStarted = true;
+            if (this.hb.clicked || (this.hb.hovered && CInputActionSet.select.isJustPressed())) {
+                int curIdx = pages.indexOf(currentPage);
+                if (forward && curIdx < pages.size() - 1)
+                    currentPage = pages.get(curIdx + 1);
+                else if (!forward && curIdx > 0)
+                    currentPage = pages.get(curIdx - 1);
+                this.hb.clicked = false;
+            }
+        }
+
+        public void render(SpriteBatch sb) {
+            sb.setColor(Color.WHITE);
+            int curIdx = pages.indexOf(currentPage);
+            if (!forward && curIdx > 0) {
+                TextureRegion region = new TextureRegion(texture);
+                sb.draw(region, x - 64.0F * Settings.scale, y - 64.0F * Settings.scale, 128.0F, 128.0F, 128.0F, 128.0F, Settings.scale / 2, Settings.scale / 2, 0.0F);
+                hb.render(sb);
+            }
+            if (forward && curIdx < pages.size() - 1) {
+                TextureRegion flippedRegion = new TextureRegion(texture);
+                flippedRegion.flip(true, false);
+                sb.draw(flippedRegion, x - 64.0F * Settings.scale, y - 64.0F * Settings.scale, 128.0F, 128.0F, 128.0F, 128.0F, Settings.scale / 2, Settings.scale / 2, 0.0F);
+                hb.render(sb);
+            }
+        }
+
+        public void hide() {
+            this.hb.move(this.hb.x, Settings.HEIGHT + 200.0F * Settings.scale);
+        }
+    }
+}


### PR DESCRIPTION
adds 1 hook (post shop initialization), 1 new abstraction (custom shop items), and wraps a paginated grid around the 2x3 shop display to allow modders to more easily add items to the shop and prevent overlapping issues

while developing another mod, I realized that we don't have a consistent way of managing shop items (potions/relics) nor is there a way to easily implement new shop items. with more mods coming out that are implementing their own shop items by hand (e.g. Risk of Relics), I thought it was necessary to come up with something that would let us add as many shop items as we like

i implemented this into my own mod as an example of how it works: https://github.com/TheDanDLion/FourthKey/pull/1/files
you basically just have to implement a new custom shop item, subscribe to the hook, then use the static method to add the item to the grid. it should dynamically add/remove pages