### PR TITLE
add overload to addCharacter

### DIFF
--- a/mod/src/main/java/basemod/BaseMod.java
+++ b/mod/src/main/java/basemod/BaseMod.java
@@ -1726,6 +1726,12 @@ public class BaseMod {
 		addCharacter(character, selectButtonPath, portraitPath, characterID, null);
 	}
 
+	public static void addCharacter(AbstractPlayer character,
+									String selectButtonPath,
+									String portraitPath) {
+		addCharacter(character, selectButtonPath, portraitPath, character.chosenClass, null);
+	}
+
 	public static TextureAtlas.AtlasRegion getCardSmallEnergy() {
 		if (AbstractDungeon.player == null) {
 			return AbstractCard.orb_red;


### PR DESCRIPTION
the PlayerClass parameter is usually unnecessary when the character instance already has it available