### PR TITLE
Fix a bug that magic number doesn't reset if a card modifier modified it once

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/CardModifierPatches.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/CardModifierPatches.java
@@ -127,10 +127,8 @@ public class CardModifierPatches
         //modifyBaseMagic
         public static void Prefix(AbstractCard __instance) {
             int magic = (int) CardModifierManager.onModifyBaseMagic(__instance.baseMagicNumber, __instance);
-            if (magic != __instance.baseMagicNumber) {
-                __instance.magicNumber = magic;
-                __instance.isMagicNumberModified = true;
-            }
+            __instance.magicNumber = magic;
+            __instance.isMagicNumberModified = magic != __instance.baseMagicNumber;
         }
 
         //onApplyPowers
@@ -226,10 +224,8 @@ public class CardModifierPatches
         //modifyBaseMagic
         public static void Prefix(AbstractCard __instance) {
             int magic = (int) CardModifierManager.onModifyBaseMagic(__instance.baseMagicNumber, __instance);
-            if (magic != __instance.baseMagicNumber) {
-                __instance.magicNumber = magic;
-                __instance.isMagicNumberModified = true;
-            }
+            __instance.magicNumber = magic;
+            __instance.isMagicNumberModified = magic != __instance.baseMagicNumber;
         }
 
         //onCalculateCardDamage


### PR DESCRIPTION
The bug is: If a card modifier changed base magic number on certain condition and reset it to the default value, magic number (not base) is still shown and use old value.