### PR TITLE
prevent TwitchVoter from crashing when initialized without a vote

### DIFF
--- a/mod/src/main/java/basemod/patches/de/robojumper/ststwitch/TwitchVoter/TwitchVoterNoCrash.java
+++ b/mod/src/main/java/basemod/patches/de/robojumper/ststwitch/TwitchVoter/TwitchVoterNoCrash.java
@@ -1,0 +1,19 @@
+package basemod.patches.de.robojumper.ststwitch.TwitchVoter;
+
+import basemod.ReflectionHacks;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
+import de.robojumper.ststwitch.TwitchConfig;
+import de.robojumper.ststwitch.TwitchVoteOption;
+import de.robojumper.ststwitch.TwitchVoter;
+
+@SpirePatch(
+        clz = TwitchVoter.class,
+        method = SpirePatch.CONSTRUCTOR
+)
+public class TwitchVoterNoCrash {
+    @SpirePostfixPatch
+    public static void initializeOptions(TwitchVoter __instance, TwitchConfig config) {
+        ReflectionHacks.setPrivate(__instance, TwitchVoter.class, "options", new TwitchVoteOption[0]);
+    }
+}


### PR DESCRIPTION
options starts out as null, this changes that.
I decided this was the minimally invasive method to fix this, as the TwitchVoter is normally only initialized once anyways, with old options never cleared.

Main thing this fixes is slay the streamer crashing with any mod that adds enemies due to 
monster registered -> basemod autogenerates group name by initializing monsters -> slay the streamer patch on AbstractMonster constructor happens and initializes TwitchVoter -> TwitchVoter exists with no options