### PR TITLE
Fix GameActionManager:queueExtraCard crash

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/actions/GameActionManager/QueueExtraCardsPatch.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/actions/GameActionManager/QueueExtraCardsPatch.java
@@ -1,0 +1,29 @@
+package basemod.patches.com.megacrit.cardcrawl.actions.GameActionManager;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireInstrumentPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch2;
+import com.megacrit.cardcrawl.actions.GameActionManager;
+import com.megacrit.cardcrawl.cards.CardQueueItem;
+import javassist.CannotCompileException;
+import javassist.expr.ExprEditor;
+import javassist.expr.FieldAccess;
+
+@SpirePatch2(clz= GameActionManager.class, method = "queueExtraCard")
+public class QueueExtraCardsPatch {
+    // Fixes the crash that happens when this method is called after the turn has ended because that queues an empty cardQueueItem
+    @SpireInstrumentPatch
+    public static ExprEditor instrument() {
+        return new ExprEditor() {
+            @Override
+            public void edit(FieldAccess f) throws CannotCompileException {
+                if (f.getClassName().equals(CardQueueItem.class.getName()) && f.getFieldName().equals("card")) {
+                    f.replace("{" +
+                            "if(c.card != null) { $_= $proceed($$); }" +
+                            // This card will never have the same UUID as the last one, so it'll be false.
+                            "else { $_ = new com.megacrit.cardcrawl.cards.status.Dazed();}" +
+                            "}");
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
As alch pointed out, this method is not very safe to use, especially in situations where it's queues at the end of the turn.
```
Alchyr wrote:
When you end your turn, a CardQueueItem with a null card is queued to mark the "end" of the turn in queue

if queueExtraCard gets called after you click the end turn button, it causes a null pointer exception
which can be done by queueing up some stuff and clicking end turn before the thing happens
```

To fix this, I instrument the fieldaccess to overwrite the return of c.card with a new Dazed in case it is null. This way we prevent the crash and since it's a new card the uuid will never be the same as the current card's.

The instrumentation looks like this in the out-jar
```
for (final CardQueueItem cardQueueItem : AbstractDungeon.actionManager.cardQueue) {
            final CardQueueItem c = cardQueueItem;
            Object card2;
            if (c.card != null) {
                card2 = cardQueueItem.card;
            }
            else {
                card2 = new Dazed();
            }
            if (((AbstractCard)card2).uuid.equals(card.uuid)) {
                ++extraCount;
            }
        }
```