### PR TITLE
prevent event ending with combat from locking

### DIFF
--- a/mod/src/main/java/basemod/abstracts/events/phases/CombatPhase.java
+++ b/mod/src/main/java/basemod/abstracts/events/phases/CombatPhase.java
@@ -147,7 +147,8 @@ public class CombatPhase extends EventPhase {
     @Override
     public boolean reopen(PhasedEvent phasedEvent) {
         if (waitingRewards) {
-            AbstractDungeon.getCurrRoom().phase = AbstractRoom.RoomPhase.INCOMPLETE;
+            if (hasFollowup())
+                AbstractDungeon.getCurrRoom().phase = AbstractRoom.RoomPhase.INCOMPLETE;
             waitingRewards = false;
             phasedEvent.waitTimer = 69; //will not reopen again until reward screen is finished
             //See EventCombatProceed


### PR DESCRIPTION
endsWithRewardsUI boolean when registering fixes a certain bug with save and quit/reload, but it also adds a bug where you cannot move to the next room unless you save/quit and reload as it skips the original logic that would have set the room to complete

this fixes that bug

tested locally, but my basemod setup is messy so I just made the change on web instead of through intellij