### PR TITLE
Revert "Fix a bug that magic number doesn't reset if a card modifier modified it once"

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/CardModifierPatches.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/CardModifierPatches.java
@@ -134,8 +134,10 @@ public class CardModifierPatches
         //modifyBaseMagic
         public static void Prefix(AbstractCard __instance) {
             int magic = (int) CardModifierManager.onModifyBaseMagic(__instance.baseMagicNumber, __instance);
-            __instance.magicNumber = magic;
-            __instance.isMagicNumberModified = magic != __instance.baseMagicNumber;
+            if (magic != __instance.baseMagicNumber) {
+                __instance.magicNumber = magic;
+                __instance.isMagicNumberModified = true;
+            }
         }
 
         //onApplyPowers
@@ -231,8 +233,10 @@ public class CardModifierPatches
         //modifyBaseMagic
         public static void Prefix(AbstractCard __instance) {
             int magic = (int) CardModifierManager.onModifyBaseMagic(__instance.baseMagicNumber, __instance);
-            __instance.magicNumber = magic;
-            __instance.isMagicNumberModified = magic != __instance.baseMagicNumber;
+            if (magic != __instance.baseMagicNumber) {
+                __instance.magicNumber = magic;
+                __instance.isMagicNumberModified = true;
+            }
         }
 
         //onCalculateCardDamage


### PR DESCRIPTION
Reverts daviscook477/BaseMod#418
Reverting on request as it causes the secondary block of Halt to not be affected by Dexterity.