### PR TITLE
Fix getNormalColor is not called by RenderCustomDynamicVariableCN

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderCustomDynamicVariableCN.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderCustomDynamicVariableCN.java
@@ -41,7 +41,7 @@ public class RenderCustomDynamicVariableCN
 						tmp[0] = "[#" + dv.getDecreasedValueColor().toString() + "]" + Integer.toString(dv.value(__instance)) + "[]";
 					}
 				} else {
-					tmp[0] = Integer.toString(dv.modifiedBaseValue(__instance));
+					tmp[0] = "[#" + dv.getNormalColor().toString() + "]" + Integer.toString(dv.modifiedBaseValue(__instance)) + "[]";
 				}
 			}
 		}

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderCustomDynamicVariableCN.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderCustomDynamicVariableCN.java
@@ -43,7 +43,7 @@ public class RenderCustomDynamicVariableCN
 					}
 				} else {
 					//cardmods affect base variables
-					tmp[0] = Integer.toString(dv.modifiedBaseValue(card));
+					tmp[0] = "[#" + dv.getNormalColor().toString() + "]" + Integer.toString(dv.modifiedBaseValue(card)) + "[]";
 				}
 			}
 		}


### PR DESCRIPTION
This PR solves:
After overwritted getNormalColor in DynamicVariable, it doesn't take effect when the game language is zhs.