### PR TITLE
Update AddCustomMonsters.java to use deep copy

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/monsters/MonsterInfo/AddCustomMonsters.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/monsters/MonsterInfo/AddCustomMonsters.java
@@ -22,13 +22,20 @@ public class AddCustomMonsters
 
 		switch (calls) {
 			case 1: // Normal monsters
-				monsters[0].addAll(BaseMod.getMonsterEncounters(AbstractDungeon.id));
+				for(MonsterInfo i:BaseMod.getMonsterEncounters(AbstractDungeon.id)){
+					monsters[0].add(new MonsterInfo(i.name,i.weight);
+				}
 				break;
 			case 2: // Strong monsters
-				monsters[0].addAll(BaseMod.getStrongMonsterEncounters(AbstractDungeon.id));
+				for(MonsterInfo i:BaseMod.getStrongMonsterEncounters(AbstractDungeon.id)){
+					monsters[0].add(new MonsterInfo(i.name,i.weight);
+				}
 				break;
 			case 3: // Elites
-				monsters[0].addAll(BaseMod.getEliteEncounters(AbstractDungeon.id));
+				for(MonsterInfo i:BaseMod.getEliteEncounters(AbstractDungeon.id)){
+					monsters[0].add(new MonsterInfo(i.name,i.weight);
+				}
+				break;
 			default:
 				calls = 0;
 				break;

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/monsters/MonsterInfo/AddCustomMonsters.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/monsters/MonsterInfo/AddCustomMonsters.java
@@ -23,17 +23,17 @@ public class AddCustomMonsters
 		switch (calls) {
 			case 1: // Normal monsters
 				for(MonsterInfo i:BaseMod.getMonsterEncounters(AbstractDungeon.id)){
-					monsters[0].add(new MonsterInfo(i.name,i.weight);
+					monsters[0].add(new MonsterInfo(i.name,i.weight));
 				}
 				break;
 			case 2: // Strong monsters
 				for(MonsterInfo i:BaseMod.getStrongMonsterEncounters(AbstractDungeon.id)){
-					monsters[0].add(new MonsterInfo(i.name,i.weight);
+					monsters[0].add(new MonsterInfo(i.name,i.weight));
 				}
 				break;
 			case 3: // Elites
 				for(MonsterInfo i:BaseMod.getEliteEncounters(AbstractDungeon.id)){
-					monsters[0].add(new MonsterInfo(i.name,i.weight);
+					monsters[0].add(new MonsterInfo(i.name,i.weight));
 				}
 				break;
 			default:

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/monsters/MonsterInfo/AddCustomMonsters.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/monsters/MonsterInfo/AddCustomMonsters.java
@@ -22,18 +22,18 @@ public class AddCustomMonsters
 
 		switch (calls) {
 			case 1: // Normal monsters
-				for(MonsterInfo i:BaseMod.getMonsterEncounters(AbstractDungeon.id)){
-					monsters[0].add(new MonsterInfo(i.name,i.weight));
+				for (MonsterInfo i : BaseMod.getMonsterEncounters(AbstractDungeon.id)) {
+					monsters[0].add(new MonsterInfo(i.name, i.weight));
 				}
 				break;
 			case 2: // Strong monsters
-				for(MonsterInfo i:BaseMod.getStrongMonsterEncounters(AbstractDungeon.id)){
-					monsters[0].add(new MonsterInfo(i.name,i.weight));
+				for (MonsterInfo i : BaseMod.getStrongMonsterEncounters(AbstractDungeon.id)) {
+					monsters[0].add(new MonsterInfo(i.name, i.weight));
 				}
 				break;
 			case 3: // Elites
-				for(MonsterInfo i:BaseMod.getEliteEncounters(AbstractDungeon.id)){
-					monsters[0].add(new MonsterInfo(i.name,i.weight));
+				for (MonsterInfo i : BaseMod.getEliteEncounters(AbstractDungeon.id)) {
+					monsters[0].add(new MonsterInfo(i.name, i.weight));
 				}
 				break;
 			default:


### PR DESCRIPTION
The original version may cause a potential issue that the saved custom encounters will get their weights modified each time the patched method normalizeWeights() is called. In vanilla game that happens generally only once over an act of dungeon, by calling generateWeakEnemies()/ generateStrongEnemies()/ generateElites() by calling generateMonsters(). However, some of these methods are not determined to be called only once under the modding environment. Therefore, I suggest adopting a deep copy to make sure the saved custom encounters will never be changed no matter how many times normalizeWeights() is called, which may improve explainability.