### PR TITLE
Fix Custom Character Names Not Appearing in Character Stat Screen for Chinese

### DIFF
--- a/mod/src/main/java/basemod/BaseMod.java
+++ b/mod/src/main/java/basemod/BaseMod.java
@@ -783,8 +783,13 @@ public class BaseMod {
 		StringBuilder retVal = new StringBuilder();
 		Scanner s = new Scanner(input);
 		while (s.hasNext()) {
-			retVal.append("[").append(colorValue).append("]").append(s.next());
-			retVal.append(" ");
+			if(Settings.language == Settings.GameLanguage.ZHS || Settings.language == Settings.GameLanguage.ZHT){
+				retVal.append("[").append(colorValue).append("]").append(s.next());
+				retVal.append("[]");
+			}else {
+				retVal.append("[").append(colorValue).append("]").append(s.next());
+				retVal.append(" ");
+			}
 		}
 		s.close();
 		return retVal.toString().trim();


### PR DESCRIPTION
I don't know since when but the custom character names don't appear for Chinese(both zhs and zht) at the characte stat screen, but other lans are fine(including korean which uses similar text rendering functions). If I remember correctly the bug was recent, but rather mysteriously the part I changed hasn't been touched for years. Either my memory is wrong or  something else made the bug happen, likely a mts commit.
![image](https://github.com/user-attachments/assets/89be061c-2452-4066-8527-757dd8455423)
![image](https://github.com/user-attachments/assets/51fdb0bb-229b-40e0-bdb9-b3d1230332d2)
![image](https://github.com/user-attachments/assets/3ed6df20-cc91-4934-8c1c-4594898a8bc7)
(happens to zht too)

This patch fixes the bug.

![image](https://github.com/user-attachments/assets/56e3c8cc-7dfd-4f96-b542-e2bb8ef7a9fd)