### PR TITLE
Fix card modifier serializable detection for anonymous class

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/CardModifierPatches.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/CardModifierPatches.java
@@ -782,7 +782,10 @@ public class CardModifierPatches
                         }
                         Object object = unsafe.allocateInstance(foundClass);
                         String serialized = gson.toJson(object);
-                        gson.fromJson(serialized, foundClass);
+                        Object deserialized = gson.fromJson(serialized, foundClass);
+                        if (deserialized == null) {
+                            throw new Exception("The card modifier is not serialized correctly.");
+                        }
                         modifierAdapter.registerSubtype(foundClass, info.getClassName());
                     } catch (Exception e) {
                         BaseMod.logger.warn("Test serialization failed on class " + foundClass + ".");


### PR DESCRIPTION
If a card modifier is anonymous class, current serializable detection will success. Then serializing of all other card modifiers may fail. This PR add a null check to cover this case.