### PR TITLE
fixed 'editing' misspelled as 'editting' in a couple places

### DIFF
--- a/mod/src/main/java/basemod/BaseMod.java
+++ b/mod/src/main/java/basemod/BaseMod.java
@@ -1155,7 +1155,7 @@ public class BaseMod {
 				registerBottleRelic(((CustomBottleRelic) relic).isOnCard(), relic);
 			}
 		} else {
-			logger.error("could not add relic to non existent custom pool: " + color);
+			logger.error("could not add relic to non-existent custom pool: " + color);
 		}
 	}
 
@@ -2685,7 +2685,7 @@ public class BaseMod {
 
 	// publishEditKeywords
 	public static void publishEditKeywords() {
-		logger.info("editting keywords");
+		logger.info("editing keywords");
 
 		addKeyword(new String[] { "[E]" }, GameDictionary.TEXT[0]);
 

--- a/testmod/src/main/java/basemod/test/TestMod.java
+++ b/testmod/src/main/java/basemod/test/TestMod.java
@@ -379,7 +379,7 @@ public class TestMod implements
 
 	@Override
 	public void receiveEditStrings() {
-		loudWrite(writer, "begin editting strings");
+		loudWrite(writer, "begin editing strings");
 		
 		// RelicStrings
 		String relicStrings = Gdx.files.internal(
@@ -393,38 +393,38 @@ public class TestMod implements
 				String.valueOf(StandardCharsets.UTF_8));
 		BaseMod.loadCustomStrings(CardStrings.class, cardStrings);
 		
-		loudWrite(writer, "end editting strings");
+		loudWrite(writer, "end editing strings");
 	}
 
 	@Override
 	public void receiveEditRelics() {
-		loudWrite(writer, "begin editting relics");
+		loudWrite(writer, "begin editing relics");
 		
 		RelicLibrary.add(new Arcanosphere());
 		
-		loudWrite(writer, "end editting relics");
+		loudWrite(writer, "end editing relics");
 	}
 
 	@Override
 	public void receiveEditCharacters() {
-		loudWrite(writer, "begin editting characters");
+		loudWrite(writer, "begin editing characters");
 
 		BaseMod.addCharacter(new Purpleclad(CardCrawlGame.playerName),
 				makePath(ASSET_FOLDER, PURPLECLAD_BUTTON),
 				makePath(ASSET_FOLDER, PURPLECLAD_PORTRAIT),
 				CharacterEnumPatch.THE_PURPLECLAD);
 		
-		loudWrite(writer, "done editting characters");
+		loudWrite(writer, "done editing characters");
 	}
 
 	@Override
 	public void receiveEditCards() {
-		loudWrite(writer, "begin editting cards");
+		loudWrite(writer, "begin editing cards");
 		
 		BaseMod.addCard(new Strike_Purple());
 		BaseMod.addCard(new Defend_Purple());
 		
-		loudWrite(writer, "End editting cards");
+		loudWrite(writer, "End editing cards");
 	}
 
 	public void saveFieldTest() {


### PR DESCRIPTION
I noticed a spelling mistake and it fueled the fires of rage inside me so that I was compelled to make this very important pull request.