### PR TITLE
a fix of frequently creating instances when rendering upgraded cards

### DIFF
--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderInLibrary.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/cards/AbstractCard/RenderInLibrary.java
@@ -1,0 +1,51 @@
+package basemod.patches.com.megacrit.cardcrawl.cards.AbstractCard;
+
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpireField;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePrefixPatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpireReturn;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.screens.SingleCardViewPopup;
+
+public class RenderInLibrary {
+    @SpirePatch(
+            clz = AbstractCard.class,
+            method = SpirePatch.CLASS
+    )
+    public static class UpgradeCard
+    {
+        public static SpireField<AbstractCard> upgradeCard = new SpireField<>(() -> null);
+    }
+
+    @SpirePatch(
+            clz = AbstractCard.class,
+            method = "renderInLibrary",
+            paramtypez = {SpriteBatch.class}
+    )
+    public static class FixRenderLibraryUpgrade
+    {
+        @SpirePrefixPatch
+        public static SpireReturn<Void> prefix(AbstractCard __instance, SpriteBatch sb)
+        {
+            if (SingleCardViewPopup.isViewingUpgrade) {
+                if (UpgradeCard.upgradeCard.get(__instance) == null) {
+                    UpgradeCard.upgradeCard.set(__instance, __instance.makeCopy());
+                    UpgradeCard.upgradeCard.get(__instance).upgrade();
+                    UpgradeCard.upgradeCard.get(__instance).displayUpgrades();
+                }
+                UpgradeCard.upgradeCard.get(__instance).current_x = __instance.current_x;
+                UpgradeCard.upgradeCard.get(__instance).current_y = __instance.current_y;
+                UpgradeCard.upgradeCard.get(__instance).drawScale = __instance.drawScale;
+
+                UpgradeCard.upgradeCard.get(__instance).render(sb);
+                return SpireReturn.Return();
+            } else if (UpgradeCard.upgradeCard.get(__instance) != null) {
+                UpgradeCard.upgradeCard.set(__instance, null);
+            }
+            return SpireReturn.Continue();
+        }
+
+    }
+
+}

--- a/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderUpgradeCard.java
+++ b/mod/src/main/java/basemod/patches/com/megacrit/cardcrawl/screens/SingleCardViewPopup/RenderUpgradeCard.java
@@ -1,0 +1,95 @@
+package basemod.patches.com.megacrit.cardcrawl.screens.SingleCardViewPopup;
+
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.screens.SingleCardViewPopup;
+import javassist.CtBehavior;
+
+import java.lang.reflect.Field;
+
+public class RenderUpgradeCard
+{
+    @SpirePatch(
+            clz = SingleCardViewPopup.class,
+            method = SpirePatch.CLASS
+    )
+    public static class UpgradeStatus
+    {
+        public static SpireField<Boolean> preViewingUpgrade = new SpireField<>(() -> false);
+        public static SpireField<Boolean> nowViewingUpgrade = new SpireField<>(() -> false);
+        public static SpireField<AbstractCard> originalCard = new SpireField<>(() -> null);
+    }
+
+    @SpirePatch2(
+            clz = SingleCardViewPopup.class,
+            method = "render",
+            paramtypez = {SpriteBatch.class}
+    )
+    public static class FixRenderUpgrade
+    {
+        @SpirePrefixPatch
+        public static void prefix(SingleCardViewPopup __instance)
+        {
+            // disable isViewingUpgrade in this method
+            UpgradeStatus.nowViewingUpgrade.set(__instance, SingleCardViewPopup.isViewingUpgrade);
+            SingleCardViewPopup.isViewingUpgrade = false;
+            if (UpgradeStatus.nowViewingUpgrade.get(__instance) != UpgradeStatus.preViewingUpgrade.get(__instance)) {
+                Field cardField;
+                try {
+                    cardField = SingleCardViewPopup.class.getDeclaredField("card");
+                    cardField.setAccessible(true);
+                    if (UpgradeStatus.nowViewingUpgrade.get(__instance)) {
+                        // isViewUpgrade just false -> true
+                        AbstractCard card = (AbstractCard) cardField.get(__instance);
+                        UpgradeStatus.originalCard.set(__instance, card.makeStatEquivalentCopy());
+                        card.upgrade();
+                        card.displayUpgrades();
+                    } else {
+                        // isViewUpgrade just true -> false
+                        cardField.set(__instance, UpgradeStatus.originalCard.get(__instance));
+                    }
+                } catch (NoSuchFieldException | IllegalAccessException e) {
+                    e.printStackTrace();
+                }
+
+            }
+
+        }
+
+        @SpireInsertPatch(locator = Locator.class)
+        public static void insert(SingleCardViewPopup __instance)
+        {
+            SingleCardViewPopup.isViewingUpgrade = UpgradeStatus.nowViewingUpgrade.get(__instance);
+            UpgradeStatus.preViewingUpgrade.set(__instance, SingleCardViewPopup.isViewingUpgrade);
+        }
+
+        private static class Locator extends SpireInsertLocator
+        {
+            @Override
+            public int[] Locate(CtBehavior ctBehavior) throws Exception {
+                Matcher matcher = new Matcher.MethodCallMatcher(SpriteBatch.class, "setColor");
+                return LineFinder.findInOrder(ctBehavior, matcher);
+            }
+        }
+
+    }
+
+    @SpirePatch(
+            clz = SingleCardViewPopup.class,
+            method = "close"
+    )
+    public static class CloseFix
+    {
+        @SpirePostfixPatch
+        public static void postfix(SingleCardViewPopup __instance)
+        {
+            UpgradeStatus.nowViewingUpgrade.set(__instance, false);
+            UpgradeStatus.preViewingUpgrade.set(__instance, false);
+            if (UpgradeStatus.originalCard.get(__instance) != null) {
+                UpgradeStatus.originalCard.set(__instance, null);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
In card library, if you viewing upgraded cards -- both in library and in single card view,  the game will new a temporary instance of cards to render. This happened in every frame and a new instance of AbstractCard means heap consumption from portrait (AtlasRegion object) of the card. Thus, I noticed a heavy use of heap when viewing upgraded cards.  
![屏幕截图 2025-06-17 221609](https://github.com/user-attachments/assets/5047d6db-4ec2-4351-bdbf-c4721a939441)  
Graph above running with BaseMod v5.55.3 only  
  
Thus, I added two patches to make SingleCardViewPopup and AbstractCard create new instance if need. There is still constantly consuming heap, but the speed is much smaller.  
![屏幕截图 2025-06-18 161654](https://github.com/user-attachments/assets/df3fb434-459b-4fc7-9de1-af5c643efc70)  
Graph above running with BaseMod v5.55.3 and my patches  

The only **problem** is that I use SpireReturn in patching AbstractCard.renderInLibrary (in RenderInLibrary.java). I am not sure whether it means problems or not.